### PR TITLE
fix: correction du gitignore pour ne pas tenir compte des statics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,9 @@ ENV/
 # Rope project settings
 .ropeproject
 
+# statics
+noethysweb/static/
+
 # =========================
 # Operating System Files
 # =========================


### PR DESCRIPTION
Bonjour,

Le but de cette PR est d'ajouter le répertoire des statics dans le .gitignore afin de faciliter le développement en évitant ainsi d'inclure par accident les statics lors d'un commit commits.