### PR TITLE
fix: fixe la version de django sur une version compatible

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django
+Django<4
 Pillow
 django-anymail
 django-axes


### PR DESCRIPTION
Bonjour,

Généralement dans les projets python la version des dépendances est fixé dans le fichier `requirements.txt`, cela évite de se retrouver avec des versions incompatibles de dépendances avec le projet. Cela permet aussi de connaitre à l'avance les versions utilisés pour avoir un environnement reproductible.

Avec cette PR je ne souhaite pas fixer toutes les dépendances, mais au moins éliminer les dépendances incompatible.
Le projet n'ayant pas l'air de fonctionner avec un Django 4 ou plus récent, je propose simplement de limiter la version de Django à une version < 4. Cela facilitera l'installation du projet car la version de Django qui permet de le faire tourner sera directement installé.