### PR TITLE
fix: correction du système d'installation des dépendances

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,11 @@ Installation
 ------------------------
 
 - Téléchargez le code source.
-- Installez python 3 et les dépendances du fichier *requirements.txt* :
+- Installez python 3.
+- Si vous êtes en prod, installez les dépendances du fichier *requirements.txt* :
     - `pip3 install -r requirements.txt`
+- Si vous êtes en dev, installez les dépendances du fichier *requirements-dev.txt* :
+    - `pip3 install -r requirements-dev.txt`
 - Allez dans le répertoire *noethysweb/noethysweb* et renommez le fichier *settings_production_modele.py* en *settings_production.py*.
 - Personnalisez le fichier *settings_production.py* selon vos besoins.
 - Exécutez les commandes suivantes depuis le répertoire *noethysweb* :

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+-r requirements.txt
+django-debug-toolbar

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,6 @@ django-cryptography
 django-crispy-forms
 django-csp
 django-datatable-view
-django-debug-toolbar
 django-formtools
 django-multiselectfield
 django-simple-captcha


### PR DESCRIPTION
Bonjour,

Cette PR propose la mise en place d'un système permettant de déployer facilement des dépendances différentes en prod et en dev. En effet, en production il est recommandé de ne pas déployer les dépendances de dev car elle ne sont pas nécessaire et cela limite la surface d'attaque.

J'ai donc séparé le fichier `requirements.txt` en deux : 
* `requirements.txt` : contient toutes les dépendances pour déployer en production
* `requirements-dev.txt` : contient les dépendances à ajouter en plus lors du développement, ainsi qu'un lien vers le fichier `requirements.txt` pour installer aussi les autres dépendances.

Avec ce système on utilisera donc deux commandes différentes en fonction de l'env pour installer les dépendances :
* En prod : `pip3 install -r requirements.txt`
* En dev : `pip3 install -r requirements-dev.txt`