### PR TITLE
feat: Ajout d'un système permettant de déployer plusieurs Noethys sur un même domaine

### DIFF
--- a/noethysweb/core/context_processors.py
+++ b/noethysweb/core/context_processors.py
@@ -1,0 +1,14 @@
+# -*- coding: utf-8 -*-
+#  Copyright (c) 2019-2021 Ivan LUCAS.
+#  Noethysweb, application de gestion multi-activités.
+#  Distribué sous licence GNU GPL.
+
+from django.conf import settings
+
+
+def url_root(request):
+    """
+    Ajoute URL_ROOT au contexte de tous les templates pour permettre
+    l'accès à cette variable dans les templates si nécessaire
+    """
+    return {'URL_ROOT': settings.URL_ROOT}

--- a/noethysweb/core/middleware.py
+++ b/noethysweb/core/middleware.py
@@ -1,0 +1,95 @@
+# -*- coding: utf-8 -*-
+#  Copyright (c) 2019-2021 Ivan LUCAS.
+#  Noethysweb, application de gestion multi-activités.
+#  Distribué sous licence GNU GPL.
+
+from django.conf import settings
+from django.http import HttpResponseRedirect
+from django.urls.base import set_script_prefix, get_script_prefix
+
+
+class URLPrefixMiddleware:
+    """Middleware pour gérer le préfixe URL_ROOT"""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+
+        if not settings.URL_ROOT:
+            # Pas de préfixe, comportement normal
+            return self.get_response(request)
+
+        # Normaliser URL_ROOT
+        url_prefix = settings.URL_ROOT.strip('/')
+        if not url_prefix:
+            return self.get_response(request)
+
+        # Si l'URL commence déjà par le préfixe, on retire le préfixe pour le
+        # traitement interne
+        # Exemple: /app1/administrateur/ -> /administrateur/
+        if request.path_info.startswith(f'/{url_prefix}/'):
+            # Sauvegarde le chemin original pour une utilisation future
+            request.original_path = request.path_info
+            # Retire le préfixe du chemin
+            request.path_info = request.path_info[len(f'/{url_prefix}'):]
+            # Traite la requête normalement
+            return self.get_response(request)
+
+        # Si l'URL est exactement égale au préfixe (avec ou sans slash)
+        elif (request.path_info == f'/{url_prefix}' or
+              request.path_info == f'/{url_prefix}/'):
+            request.original_path = request.path_info
+            request.path_info = '/'
+            return self.get_response(request)
+
+        # Si l'URL est une URL standard (pas /static/ ou /media/), on la
+        # redirige vers le préfixe
+        elif not any(request.path_info.startswith(prefix)
+                     for prefix in ['/static/', '/media/']):
+            # Construction de l'URL avec le préfixe
+            new_url = f'/{url_prefix}{request.path_info}'
+            # Si l'URL se termine par un slash et que new_url a un double
+            # slash, on le corrige
+            new_url = new_url.replace('//', '/')
+            # On ajoute le slash final si l'URL originale en avait un
+            if request.path_info.endswith('/') and not new_url.endswith('/'):
+                new_url += '/'
+            # On ajoute les paramètres de requête s'il y en a
+            if request.GET:
+                new_url += '?' + request.META.get('QUERY_STRING', '')
+            return HttpResponseRedirect(new_url)
+
+        # Tout le reste passe normalement
+        return self.get_response(request)
+
+
+class URLPrefixReverseMiddleware:
+    """Middleware pour configurer le préfixe URL utilisé par Django pour
+    générer les URLs.
+    Ce middleware utilise set_script_prefix() pour ajouter automatiquement le
+    préfixe URL_ROOT à toutes les URLs générées par Django via la fonction
+    reverse() et le tag template {% url %}."""
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        # Sauvegarder le préfixe d'origine pour le restaurer après le
+        # traitement
+        original_prefix = get_script_prefix()
+
+        try:
+            # Configurer le préfixe URL pour générer les URLs avec URL_ROOT
+            if settings.URL_ROOT:
+                # Normalisation du préfixe pour éviter les doubles slashes
+                prefix = '/' + settings.URL_ROOT.strip('/') + '/'
+                prefix = prefix.replace('//', '/')
+                set_script_prefix(prefix)
+
+            # Traiter la requête normalement
+            response = self.get_response(request)
+            return response
+        finally:
+            # Restaurer le préfixe d'origine une fois la requête traitée
+            set_script_prefix(original_prefix)

--- a/noethysweb/noethysweb/settings.py
+++ b/noethysweb/noethysweb/settings.py
@@ -337,6 +337,10 @@ AXES_LOCKOUT_URL = (
     f"{_URL_ROOT_PREFIX}/locked" if _URL_ROOT_PREFIX else '/locked'
 )
 
+# Définir le chemin des cookies pour qu'il corresponde uniquement à URL_ROOT
+SESSION_COOKIE_PATH = f"{_URL_ROOT_PREFIX}/" if _URL_ROOT_PREFIX else '/'
+CSRF_COOKIE_PATH = f"{_URL_ROOT_PREFIX}/" if _URL_ROOT_PREFIX else '/'
+
 # Intégration des plugins
 for nom_plugin in PLUGINS:
     INSTALLED_APPS.append("plugins.%s.apps.%s" % (nom_plugin, nom_plugin))

--- a/noethysweb/noethysweb/settings.py
+++ b/noethysweb/noethysweb/settings.py
@@ -9,6 +9,8 @@ import crispy_forms
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # URLS
+#  URL racine pour héberger plusieurs instances sur un même domaine
+URL_ROOT = ""
 URL_GESTION = "administrateur/"
 URL_BUREAU = "utilisateur/"
 URL_PORTAIL = ""
@@ -119,6 +121,10 @@ INTERNAL_IPS = [
 ]
 
 MIDDLEWARE = [
+    # Doit être placé avant tout pour préfixer les URLs générées
+    'core.middleware.URLPrefixReverseMiddleware',
+    # Doit être en 2ème pour gérer le préfixe URL_ROOT dans les URLs entrantes
+    'core.middleware.URLPrefixMiddleware',
     'debug_toolbar.middleware.DebugToolbarMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
@@ -126,10 +132,10 @@ MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
+    'axes.middleware.AxesMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
     'csp.middleware.CSPMiddleware',
-    'axes.middleware.AxesMiddleware',
     'noethysweb.middleware.CustomMiddleware',
 ]
 
@@ -147,6 +153,7 @@ TEMPLATES = [
                 'django.contrib.auth.context_processors.auth',
                 'django.contrib.messages.context_processors.messages',
                 'django.template.context_processors.media',
+                'core.context_processors.url_root',
             ],
         },
     },
@@ -190,14 +197,6 @@ LANGUAGES = (
 LOCALE_PATHS = (
     os.path.join(BASE_DIR, "locale"),
 )
-
-# Static files (CSS, JavaScript, Images)
-STATIC_ROOT = os.path.join(BASE_DIR, 'static')
-STATIC_URL = '/static/'
-
-# Media files
-MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
-MEDIA_URL = '/media/'
 
 # Stockage
 STORAGE_PROBLEME = "django.core.files.storage.FileSystemStorage"
@@ -319,6 +318,24 @@ try:
     from .settings_production import *
 except:
     print("Settings en production non trouvés : Utilisation des settings par défaut.")
+
+# Modification pour prendre en compte URL_ROOT
+_URL_ROOT_STRIPPED = URL_ROOT.strip("/")
+_URL_ROOT_PREFIX = f"/{_URL_ROOT_STRIPPED}" if _URL_ROOT_STRIPPED else ""
+
+# Static files (CSS, JavaScript, Images)
+STATIC_ROOT = os.path.join(BASE_DIR, 'static')
+# Modification pour prendre en compte URL_ROOT dans les chemins static
+STATIC_URL = f"{_URL_ROOT_PREFIX}/static/" if _URL_ROOT_PREFIX else '/static/'
+
+# Media files
+MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
+# Modification pour prendre en compte URL_ROOT dans les chemins media
+MEDIA_URL = f"{_URL_ROOT_PREFIX}/media/" if _URL_ROOT_PREFIX else '/media/'
+
+AXES_LOCKOUT_URL = (
+    f"{_URL_ROOT_PREFIX}/locked" if _URL_ROOT_PREFIX else '/locked'
+)
 
 # Intégration des plugins
 for nom_plugin in PLUGINS:

--- a/noethysweb/noethysweb/settings_production_modele.py
+++ b/noethysweb/noethysweb/settings_production_modele.py
@@ -37,6 +37,8 @@ DEBUG = False
 # Et de définir une URL un peu plus complexe pour le URL_BUREAU
 #########################################################################################
 
+# URL racine pour héberger plusieurs instances sur un même domaine
+URL_ROOT = ""
 URL_GESTION = "administrateur/"
 URL_BUREAU = "utilisateur/"
 URL_PORTAIL = ""

--- a/noethysweb/noethysweb/urls.py
+++ b/noethysweb/noethysweb/urls.py
@@ -1,14 +1,18 @@
+# -*- coding: utf-8 -*-
 #  Copyright (c) 2019-2021 Ivan LUCAS.
 #  Noethysweb, application de gestion multi-activités.
 #  Distribué sous licence GNU GPL.
 
 from django.contrib import admin
-from django.urls import include, path
+from django.urls import include, path, re_path
 from django.conf import settings
 from django.conf.urls.static import static
+from django.views.static import serve
+from django.contrib.staticfiles import views
+from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from core.views import erreurs
 
-
+# Définir les patterns de base
 urlpatterns = [
     path(settings.URL_GESTION, admin.site.urls),
     path(settings.URL_BUREAU, include('core.urls')),
@@ -46,14 +50,29 @@ if settings.PORTAIL_ACTIF:
     urlpatterns.append(path(settings.URL_PORTAIL, include('portail.urls')))
 
 if settings.DEBUG:
-    # Ajoute le répertoire Media
-    urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+    # Import du debug toolbar et ajout des URLs
+    import debug_toolbar
 
     # Ajoute le debugtoolbar
-    import debug_toolbar
     urlpatterns = [
         path('__debug__/', include(debug_toolbar.urls)),
     ] + urlpatterns
+
+    # Ajoute les répertoires Media et Static pour le développement
+    if settings.URL_ROOT:
+        # Pour les fichiers média avec URL_ROOT
+        urlpatterns += [
+            # Pattern pour les chemins avec le préfixe URL_ROOT
+            re_path(r'^%s(?P<path>.*)$' % settings.MEDIA_URL.lstrip('/'), serve, {'document_root': settings.MEDIA_ROOT}),
+            # Pattern pour les chemins sans le préfixe URL_ROOT (après traitement par le middleware)
+            re_path(r'^media/(?P<path>.*)$', serve, {'document_root': settings.MEDIA_ROOT}),
+            # Pattern pour les fichiers statiques avec URL_ROOT
+            re_path(r'^%s(?P<path>.*)$' % settings.STATIC_URL.lstrip('/'), views.serve, {'document_root': settings.STATIC_ROOT}),
+        ]
+    else:
+        # Configuration standard sans URL_ROOT
+        urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+        urlpatterns += staticfiles_urlpatterns()
 
 
 # Modifie les noms dans l'admin


### PR DESCRIPTION
Bonjour,

Cette PR a pour but de mettre en place un système permettant de facilement déployer plusieurs instances de noehtys sur un même domaine en le placant sur des sous uri différentes.

Par exemple on peux avoir :
- https://noethys_url.demo/instance1/
- https://noethys_url.demo/instance2/
- https://noethys_url.demo/instance3/
- etc 

La configuration se fait très simplement en spécifiant le début de l'uri dans la variable `URL_ROOT` dans `settings_production.py`.

Par exemple on peut avoir : 
- `URL_ROOT = "instance1"` pour la première instance,
- `URL_ROOT = "instance2"` pour la seconde instance,
- etc