### PR TITLE
fix: #56 variable {INDIVIDU_DATE_NAISS} corrigée pour fonctionner dan…

### DIFF
--- a/noethysweb/fiche_individu/utils/utils_inscriptions.py
+++ b/noethysweb/fiche_individu/utils/utils_inscriptions.py
@@ -47,6 +47,7 @@ class Inscriptions():
                 "{IDINDIVIDU}": inscription.individu_id,
                 "{INDIVIDU_NOM}":  inscription.individu.nom,
                 "{INDIVIDU_PRENOM}": inscription.individu.prenom,
+                "{INDIVIDU_DATE_NAISS}": utils_dates.ConvertDateToFR(inscription.individu.date_naiss) or "",            
                 "{INDIVIDU_RUE}": inscription.individu.rue_resid,
                 "{INDIVIDU_CP}": inscription.individu.cp_resid,
                 "{INDIVIDU_VILLE}": inscription.individu.ville_resid,


### PR DESCRIPTION
Bonjour,

Cette PR a pour objectif de corriger l'issue #56 .

La variable "{INDIVIDU_DATE_NAISS}" est présente dans le modèle de mail pour le mail inscription, mais si elle est utilisé dans ce type de mail, elle n'affiche jamais rien.

J'ai donc ajouté la déclaration de la variable avec le remplissage de sa valeur.