### PR TITLE
Fix #60 - Corrige la génération des pdf qui dans certains cas ne fonctionnent pas.

### DIFF
--- a/noethysweb/comptabilite/utils/utils_impression_achats.py
+++ b/noethysweb/comptabilite/utils/utils_impression_achats.py
@@ -12,7 +12,7 @@ from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.pagesizes import A4, portrait, landscape
 from reportlab.lib import colors
 from core.models import AchatArticle
-from core.utils import utils_dates, utils_impression
+from core.utils import utils_dates, utils_impression, utils_polices
 
 
 class Impression(utils_impression.Impression):
@@ -33,7 +33,7 @@ class Impression(utils_impression.Impression):
             self.erreurs.append("Aucun article n'a été trouvé avec les paramètres donnés")
 
         # Préparation des polices
-        style_centre = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceAfter=0, leading=9)
+        style_centre = ParagraphStyle(name="centre", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=7, spaceAfter=0, leading=9)
 
         # Création du titre du document
         self.Insert_header()
@@ -56,7 +56,7 @@ class Impression(utils_impression.Impression):
 
             # Nom du fournisseur
             Insert_barre_titre(label=fournisseur.nom, styles=[
-                ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (-1, -1), "Helvetica-Bold", 8),
+                ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (-1, -1), utils_polices.FONT_BOLD, 8),
                 ('GRID', (0, 0), (-1, -1), 0.25, colors.black), ('ALIGN', (0, 0), (-1, -1), "CENTRE"),
                 ('TEXTCOLOR', (0, 0), (-1, -1), (1, 1, 1)), ('BACKGROUND', (0, 0), (-1, -1), (0.5, 0.5, 0.5)),
             ])
@@ -68,7 +68,7 @@ class Impression(utils_impression.Impression):
             # Entêtes de colonnes
             tableau = Table([("Acheté", "Article", "Quantité", "Observations article", "Echéance", "Libellé demande", "Collaborateur", "Observations demande")], largeurs_colonnes)
             tableau.setStyle(TableStyle([
-                ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (-1, -1), "Helvetica", 5),
+                ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 5),
                 ('GRID', (0, 0), (-1, -1), 0.25, colors.black), ('ALIGN', (0, 0), (-1, -1), 'CENTRE'), ]))
             self.story.append(tableau)
 
@@ -78,7 +78,7 @@ class Impression(utils_impression.Impression):
 
                 # Nom de la catégorie
                 Insert_barre_titre(label=categorie.nom, styles=[
-                    ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (-1, -1), "Helvetica-Bold", 7),
+                    ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (-1, -1), utils_polices.FONT_BOLD, 7),
                     ('GRID', (0, 0), (-1, -1), 0.25, colors.black), ('ALIGN', (0, 0), (-1, -1), "LEFT"),
                     ('TEXTCOLOR', (0, 0), (-1, -1), (0, 0, 0)), ('BACKGROUND', (0, 0), (-1, -1), (0.8, 0.8, 0.8)),
                 ])
@@ -100,7 +100,7 @@ class Impression(utils_impression.Impression):
 
                 tableau = Table(dataTableau, largeurs_colonnes)
                 style = TableStyle([
-                    ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (-1, -1), "Helvetica", 7),
+                    ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
                     ('GRID', (0, 0), (-1, -1), 0.25, colors.black), ('ALIGN', (0, 0), (-1, -1), 'CENTRE'),])
                 tableau.setStyle(style)
                 self.story.append(tableau)

--- a/noethysweb/consommations/utils/utils_impression_conso.py
+++ b/noethysweb/consommations/utils/utils_impression_conso.py
@@ -15,7 +15,7 @@ from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.pagesizes import A4, portrait, landscape
 from reportlab.lib import colors
 from reportlab.graphics.barcode import code39
-from core.utils import utils_dates, utils_impression, utils_infos_individus, utils_dictionnaires
+from core.utils import utils_dates, utils_impression, utils_infos_individus, utils_dictionnaires, utils_polices
 from core.models import Activite, Ouverture, Unite, UniteRemplissage, Consommation, MemoJournee, Note, Information, Individu, \
                         Inscription, Scolarite, Classe, Ecole, Evenement, QuestionnaireQuestion, QuestionnaireChoix, Rattachement
 from individus.utils import utils_pieces_manquantes
@@ -290,9 +290,9 @@ class Impression(utils_impression.Impression):
         # --------------------------------------- Création du PDF ----------------------------------------------
 
         # Font normale
-        styleNormal = ParagraphStyle(name="normal", fontName="Helvetica", alignment=1, fontSize=7, leading=8)
-        styleEntetes = ParagraphStyle(name="entetes", fontName="Helvetica", alignment=1, fontSize=6, leading=7)
-        styleDifferences = ParagraphStyle(name="differences", fontName="Helvetica", alignment=1, fontSize=4, spaceAfter=0, leading=5, textColor=colors.grey)
+        styleNormal = ParagraphStyle(name="normal", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=7, leading=8)
+        styleEntetes = ParagraphStyle(name="entetes", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=6, leading=7)
+        styleDifferences = ParagraphStyle(name="differences", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=4, spaceAfter=0, leading=5, textColor=colors.grey)
 
         # Nom du profil
         profil = self.dict_donnees.get("profil", None)
@@ -310,10 +310,10 @@ class Impression(utils_impression.Impression):
             dataTableau = []
             largeursColonnes = ((largeur_contenu * 1.0 / 3, largeur_contenu * 2.0 / 3))
 
-            styleActivite = ParagraphStyle(name="activite", fontName="Helvetica", fontSize=self.dict_donnees["activite_taille_nom"], leading=self.dict_donnees["activite_taille_nom"], spaceAfter=0, textColor=couleurTexte)
-            styleGroupe = ParagraphStyle(name="groupe", fontName="Helvetica-Bold", fontSize=tailleGroupe, leading=tailleGroupe+2, spaceBefore=0, spaceAfter=2, textColor=couleurTexte)
-            styleEcole = ParagraphStyle(name="ecole", fontName="Helvetica", alignment=2, fontSize=5, leading=3, spaceAfter=0, textColor=couleurTexte)
-            styleClasse = ParagraphStyle(name="classe", fontName="Helvetica-Bold", alignment=2, fontSize=14, leading=16, spaceBefore=0, spaceAfter=2, textColor=couleurTexte)
+            styleActivite = ParagraphStyle(name="activite", fontName=utils_polices.FONT_NORMAL, fontSize=self.dict_donnees["activite_taille_nom"], leading=self.dict_donnees["activite_taille_nom"], spaceAfter=0, textColor=couleurTexte)
+            styleGroupe = ParagraphStyle(name="groupe", fontName=utils_polices.FONT_BOLD, fontSize=tailleGroupe, leading=tailleGroupe+2, spaceBefore=0, spaceAfter=2, textColor=couleurTexte)
+            styleEcole = ParagraphStyle(name="ecole", fontName=utils_polices.FONT_NORMAL, alignment=2, fontSize=5, leading=3, spaceAfter=0, textColor=couleurTexte)
+            styleClasse = ParagraphStyle(name="classe", fontName=utils_polices.FONT_BOLD, alignment=2, fontSize=14, leading=16, spaceBefore=0, spaceAfter=2, textColor=couleurTexte)
 
             ligne = [(Paragraph(nomActivite, styleActivite), Paragraph(nomGroupe, styleGroupe)), None]
 
@@ -554,7 +554,7 @@ class Impression(utils_impression.Impression):
                                 # Création de l'entete des DATES
                                 if len(self.dict_donnees["dates"]) > 1:
                                     ligneTempExport = []
-                                    styleDate = ParagraphStyle(name="date", fontName="Helvetica-Bold", fontSize=8, spaceAfter=0, leading=9)
+                                    styleDate = ParagraphStyle(name="date", fontName=utils_polices.FONT_BOLD, fontSize=8, spaceAfter=0, leading=9)
                                     ligne = []
                                     for index in range(0, len(labelsColonnes)-1):
                                         ligne.append("")
@@ -668,9 +668,9 @@ class Impression(utils_impression.Impression):
                                                     listeLabels = []
                                                     quantite = None
 
-                                                    styleConso = ParagraphStyle(name="label_conso", fontName="Helvetica", alignment=1, fontSize=6, leading=6, spaceBefore=0, spaceAfter=0, textColor=colors.black)
-                                                    styleEvenement = ParagraphStyle(name="label_evenement", fontName="Helvetica", alignment=1, fontSize=5, leading=5, spaceBefore=2, spaceAfter=0, textColor=colors.black)
-                                                    styleEtiquette = ParagraphStyle(name="label_etiquette", fontName="Helvetica", alignment=1, fontSize=5, leading=5, spaceBefore=2, spaceAfter=2, textColor=colors.grey)
+                                                    styleConso = ParagraphStyle(name="label_conso", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=6, leading=6, spaceBefore=0, spaceAfter=0, textColor=colors.black)
+                                                    styleEvenement = ParagraphStyle(name="label_evenement", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=5, leading=5, spaceBefore=2, spaceAfter=0, textColor=colors.black)
+                                                    styleEtiquette = ParagraphStyle(name="label_etiquette", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=5, leading=5, spaceBefore=2, spaceAfter=2, textColor=colors.grey)
 
                                                     if typeTemp == "consommation":
                                                         # Unité de Conso
@@ -910,7 +910,7 @@ class Impression(utils_impression.Impression):
 
                                     # Informations personnelles
                                     listeInfos = []
-                                    paraStyle = ParagraphStyle(name="infos", fontName="Helvetica", fontSize=7, leading=8, spaceAfter=2)
+                                    paraStyle = ParagraphStyle(name="infos", fontName=utils_polices.FONT_NORMAL, fontSize=7, leading=8, spaceAfter=2)
 
                                     # Mémo-journée
                                     if inscription.pk in dictMemos:
@@ -1034,10 +1034,10 @@ class Impression(utils_impression.Impression):
 
                                 style = [
                                     ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                                    ('FONT', (0, 0), (-1, -1), "Helvetica", 7),
+                                    ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
                                     ('ALIGN', (0, 0), (-2, -1), 'CENTRE'),
                                     ('ALIGN', (0, 0), (-1, 0), 'CENTRE'),
-                                    ('FONT', (0, 0), (-1, 0), "Helvetica", 6),
+                                    ('FONT', (0, 0), (-1, 0), utils_polices.FONT_NORMAL, 6),
                                     ('LEFTPADDING', (0, 0), (-1, 0), 0),
                                     ('RIGHTPADDING', (0, 0), (-1, 0), 0),
                                     ('LEFTPADDING', (1, 1), (-2, -1), 1),
@@ -1052,7 +1052,7 @@ class Impression(utils_impression.Impression):
                                     style.append(('LINEBEFORE', (0, 0), (0, 0), 0.25, colors.black))
                                     style.append(('LINEAFTER', (-1, 0), (-1, 0), 0.25, colors.black))
                                     style.append(('ALIGN', (0, 1), (-1, 1), 'CENTRE'))
-                                    style.append(('FONT', (0, 0), (-1, 0), "Helvetica-Bold", 8))
+                                    style.append(('FONT', (0, 0), (-1, 0), utils_polices.FONT_BOLD, 8))
                                     for date, positionG, positionD in listePositionsDates:
                                         style.append(('SPAN', (positionG, 0), (positionD, 0)))
                                         style.append(('BACKGROUND', (positionG, 0), (positionD, 0), (1, 1, 1)))
@@ -1113,7 +1113,7 @@ class Impression(utils_impression.Impression):
 
                                 style = [
                                     ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                                    ('FONT', (0, 0), (-1, -1), "Helvetica", 7),
+                                    ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
                                     ('ALIGN', (0, 0), (-1, -1), 'CENTRE'),
                                     ('GRID', (colPremiereUnite, -1), (colDerniereUnite, -1), 0.25, colors.black),
                                     ('BACKGROUND', (colPremiereUnite, -1), (colDerniereUnite, -1), self.dict_donnees["couleur_fond_total"])
@@ -1132,8 +1132,8 @@ class Impression(utils_impression.Impression):
 
                                     dataTableauRecap = []
 
-                                    style_categorie = ParagraphStyle(name="recap_categorie", fontName="Helvetica-Bold", fontSize=7, leading=8, spaceAfter=2)
-                                    style_info = ParagraphStyle(name="recap_info", fontName="Helvetica", fontSize=7, leading=8, spaceAfter=2)
+                                    style_categorie = ParagraphStyle(name="recap_categorie", fontName=utils_polices.FONT_BOLD, fontSize=7, leading=8, spaceAfter=2)
+                                    style_info = ParagraphStyle(name="recap_info", fontName=utils_polices.FONT_NORMAL, fontSize=7, leading=8, spaceAfter=2)
 
                                     info_par_categories = {}
                                     for info in recapitulatif["informations"]:
@@ -1153,7 +1153,7 @@ class Impression(utils_impression.Impression):
                                     if dataTableauRecap:
                                         styleRecap = [
                                             ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                                            ('FONT', (0, 0), (-1, -1), "Helvetica", 7),
+                                            ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
                                             ('ALIGN', (0, 0), (-1, -1), 'CENTRE'),
                                             ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
                                             ('BACKGROUND', (0, 0), (-1, -1), self.dict_donnees["couleur_fond_entetes"])

--- a/noethysweb/consommations/utils/utils_impression_etat_global.py
+++ b/noethysweb/consommations/utils/utils_impression_etat_global.py
@@ -10,7 +10,7 @@ from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.pagesizes import A4, portrait, landscape
 from reportlab.lib import colors
 from core.models import Evenement, Regime, Vacance, Activite, Quotient, TarifLigne, Consommation, Famille, Individu, LISTE_ETATS_CONSO, JOURS_COMPLETS_SEMAINE
-from core.utils import utils_dates, utils_impression, utils_infos_individus, utils_dictionnaires
+from core.utils import utils_dates, utils_impression, utils_infos_individus, utils_dictionnaires, utils_polices
 from core.utils.utils_dates import HeureStrEnDelta as HEURE # Ne pas supprimer : est utilisé pour la formule
 
 
@@ -495,7 +495,7 @@ class Impression(utils_impression.Impression):
         self.Insert_header(espace_apres=10)
 
         # Création de l'intro
-        style_intro = ParagraphStyle(name="intro", fontName="Helvetica", fontSize=6, leading=6, spaceBefore=0, spaceAfter=2)
+        style_intro = ParagraphStyle(name="intro", fontName=utils_polices.FONT_NORMAL, fontSize=6, leading=6, spaceBefore=0, spaceAfter=2)
         lignes_intro = [
             Paragraph(u"<b>Période :</b> Du %s au %s" % (utils_dates.ConvertDateToFR(date_debut), utils_dates.ConvertDateToFR(date_fin)), style_intro),
             Paragraph(u"<b>Activités :</b> %s" % ", ".join([activite.nom for activite in activites]), style_intro),
@@ -528,9 +528,9 @@ class Impression(utils_impression.Impression):
 
             dataTableau = []
 
-            listeStyles = [('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (-1, 0), "Helvetica-Bold", 7),
-                ('FONT', (0, -1), (-1, -1), "Helvetica", 7), ('GRID', (1, 0), (-1, -1), 0.25, colors.black),
-                ('ALIGN', (0, 0), (-1, -1), 'CENTRE'), ('FONT', (0, 0), (0, 0), "Helvetica-Bold", 7),
+            listeStyles = [('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (-1, 0), utils_polices.FONT_BOLD, 7),
+                ('FONT', (0, -1), (-1, -1), utils_polices.FONT_NORMAL, 7), ('GRID', (1, 0), (-1, -1), 0.25, colors.black),
+                ('ALIGN', (0, 0), (-1, -1), 'CENTRE'), ('FONT', (0, 0), (0, 0), utils_polices.FONT_BOLD, 7),
                 ('ALIGN', (0, 0), (0, 0), 'LEFT'), ]
 
             if dict_options["regroupement_principal"] != "aucun":
@@ -571,7 +571,7 @@ class Impression(utils_impression.Impression):
             tableau.setStyle(TableStyle(listeStyles))
             self.story.append(tableau)
 
-            paraStyle = ParagraphStyle(name="normal", fontName="Helvetica", fontSize=7, leading=7, spaceBefore=0, spaceAfter=0)
+            paraStyle = ParagraphStyle(name="normal", fontName=utils_polices.FONT_NORMAL, fontSize=7, leading=7, spaceBefore=0, spaceAfter=0)
 
             # Création des lignes
             index = 1
@@ -677,19 +677,19 @@ class Impression(utils_impression.Impression):
 
                 listeStyles = [('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
 
-                    ('FONT', (0, 0), (-1, -1), "Helvetica", 7),
+                    ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
                     ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
                     ('ALIGN', (0, 0), (-1, -1), 'CENTRE'),
 
                     ('BACKGROUND', (0, -1), (-1, -1), couleurFondClair),
                     # ('BACKGROUND', (-1, 0), (-1, -1), couleurFondClair),
 
-                    ('FONT', (0, -1), (-1, -1), "Helvetica-Bold", 7),  # Gras pour totaux
+                    ('FONT', (0, -1), (-1, -1), utils_polices.FONT_BOLD, 7),  # Gras pour totaux
                 ]
 
                 if label_tranche_age != "":
                     listeStyles.extend([('ALIGN', (0, 0), (-1, 0), 'LEFT'), ('SPAN', (0, 0), (-1, 0)),
-                        ('FONT', (0, 0), (0, 0), "Helvetica-Bold", 7),
+                        ('FONT', (0, 0), (0, 0), utils_polices.FONT_BOLD, 7),
                         ('BACKGROUND', (0, 0), (-1, 0), couleurFondFonce), ])
 
                 # Création du tableau
@@ -700,9 +700,9 @@ class Impression(utils_impression.Impression):
             # ---------- TOTAL de L'ACTIVITE --------------
             dataTableau = []
 
-            listeStyles = [('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (-1, 0), "Helvetica-Bold", 7),
-                ('FONT', (0, -1), (-1, -1), "Helvetica", 7), ('GRID', (1, 0), (-1, -1), 0.25, colors.black),
-                ('ALIGN', (0, 0), (-1, -1), 'CENTRE'), ('FONT', (0, 0), (0, 0), "Helvetica-Bold", 7),
+            listeStyles = [('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (-1, 0), utils_polices.FONT_BOLD, 7),
+                ('FONT', (0, -1), (-1, -1), utils_polices.FONT_NORMAL, 7), ('GRID', (1, 0), (-1, -1), 0.25, colors.black),
+                ('ALIGN', (0, 0), (-1, -1), 'CENTRE'), ('FONT', (0, 0), (0, 0), utils_polices.FONT_BOLD, 7),
                 ('ALIGN', (0, 0), (0, 0), 'LEFT'), ]
 
             ligne1 = ["", ]

--- a/noethysweb/consommations/utils/utils_impression_reservations.py
+++ b/noethysweb/consommations/utils/utils_impression_reservations.py
@@ -8,7 +8,7 @@ logger = logging.getLogger(__name__)
 from reportlab.platypus import Paragraph, Spacer, Table, TableStyle
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib import colors
-from core.utils import utils_dates, utils_impression, utils_preferences
+from core.utils import utils_dates, utils_impression, utils_preferences, utils_polices
 from core.models import Evenement
 
 
@@ -25,7 +25,7 @@ class Impression(utils_impression.Impression):
 
         # Texte si aucune réservation
         if len(self.dict_donnees["reservations"]) == 0:
-            paraStyle = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=11)
+            paraStyle = ParagraphStyle(name="defaut", fontName=utils_polices.FONT_NORMAL, fontSize=11)
             self.story.append(Paragraph("&nbsp;", paraStyle))
             self.story.append(Paragraph("&nbsp;", paraStyle))
             self.story.append(Paragraph("<para align='centre'><b>Aucune réservation</b></para>", paraStyle))
@@ -52,14 +52,14 @@ class Impression(utils_impression.Impression):
             totalFacturationIndividu = 0.0
 
             # Insertion du nom de l'individu
-            paraStyle = ParagraphStyle(name="individu", fontName="Helvetica", fontSize=9, spaceBefore=0, spaceafter=0)
+            paraStyle = ParagraphStyle(name="individu", fontName=utils_polices.FONT_NORMAL, fontSize=9, spaceBefore=0, spaceafter=0)
             texteIndividu = Paragraph(texteIndividu, paraStyle)
             dataTableau = []
             dataTableau.append([texteIndividu,])
             tableau = Table(dataTableau, [largeurContenu,])
             listeStyles = [
                     ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                    ('FONT', (0, 0), (-1, -1), "Helvetica", 8),
+                    ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 8),
                     ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
                     ('BACKGROUND', (0, 0), (-1, 0), couleurFond),
                     ]
@@ -79,7 +79,7 @@ class Impression(utils_impression.Impression):
                     tableau = Table(dataTableau, [largeurContenu,])
                     listeStyles = [
                         ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                        ('FONT', (0, 0), (-1, -1), "Helvetica", 6),
+                        ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 6),
                         ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
                         ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
                         ('BACKGROUND', (0, 0), (-1, 0), couleurFondActivite),
@@ -92,7 +92,7 @@ class Impression(utils_impression.Impression):
                 largeursColonnes = [55, 165, 80, 160, 60]
                 dataTableau.append(["Date", "Consommations", "Etat", "Prestations", "Total"])
 
-                paraStyle = ParagraphStyle(name="standard", fontName="Helvetica", fontSize=8, leading=10, spaceAfter=0)
+                paraStyle = ParagraphStyle(name="standard", fontName=utils_polices.FONT_NORMAL, fontSize=8, leading=10, spaceAfter=0)
 
                 # lignes DATES
                 listeDates = []
@@ -170,10 +170,10 @@ class Impression(utils_impression.Impression):
                     ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
                     ('GRID', (0, 0), (-1,-1), 0.25, colors.black),
 
-                    ('FONT', (0, 0), (-1, 0), "Helvetica", 6),
+                    ('FONT', (0, 0), (-1, 0), utils_polices.FONT_NORMAL, 6),
                     ('ALIGN', (0, 0), (-1, 0), 'CENTRE'),
 
-                    ('FONT', (0, 1), (-1, 1), "Helvetica", 8),
+                    ('FONT', (0, 1), (-1, 1), utils_polices.FONT_NORMAL, 8),
                     ]
                 tableau.setStyle(TableStyle(listeStyles))
                 self.story.append(tableau)
@@ -185,7 +185,7 @@ class Impression(utils_impression.Impression):
 
             listeStyles = [
                     ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                    ('FONT', (0, 0), (-1, -1), "Helvetica", 8),
+                    ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 8),
                     ('GRID', (-1, -1), (-1,-1), 0.25, colors.black),
                     ('ALIGN', (-1, -1), (-1, -1), 'CENTRE'),
                     ('BACKGROUND', (-1, -1), (-1, -1), couleurFond),

--- a/noethysweb/core/utils/utils_impression.py
+++ b/noethysweb/core/utils/utils_impression.py
@@ -6,7 +6,7 @@
 import logging
 logger = logging.getLogger(__name__)
 import datetime
-from core.utils import utils_dates, utils_modeles_documents, utils_preferences, utils_fichiers
+from core.utils import utils_dates, utils_modeles_documents, utils_preferences, utils_fichiers, utils_polices
 from core.models import Organisateur
 from core.data import data_modeles_emails
 from django.core.cache import cache
@@ -95,9 +95,9 @@ class MyPageTemplate(PageTemplate):
             canvas.rect(x, y, largeur, hauteur, fill=0)
             # Textes
             canvas.rotate(90)
-            canvas.setFont("Helvetica", 8)
+            canvas.setFont(utils_polices.FONT_NORMAL, 8)
             canvas.drawString(y + 2 * mm, -x - 4 * mm, "Merci de joindre ce coupon à votre règlement")
-            canvas.setFont("Helvetica", 7)
+            canvas.setFont(utils_polices.FONT_NORMAL, 7)
             if "total" in dict_valeurs:
                 solde = dict_valeurs["total"] - dict_valeurs["ventilation"]
                 if doc.dict_options["integrer_impayes"] == True:
@@ -128,9 +128,9 @@ class MyPageTemplate(PageTemplate):
             canvas.setStrokeColorRGB(0, 0, 0)
             canvas.rect(x, y, largeur, hauteur, fill=0)
             # Textes
-            canvas.setFont("Helvetica", 8)
+            canvas.setFont(utils_polices.FONT_NORMAL, 8)
             canvas.drawString(x + 2 * mm, y + hauteur - 4 * mm, "Merci de joindre ce coupon à votre règlement")
-            canvas.setFont("Helvetica", 7)
+            canvas.setFont(utils_polices.FONT_NORMAL, 7)
             if "total" in dict_valeurs:
                 solde = dict_valeurs["total"] - dict_valeurs["ventilation"]
                 if doc.dict_options["integrer_impayes"] == True:
@@ -266,8 +266,8 @@ class Impression():
         dataTableau.append((titre or self.titre, details))
         style = TableStyle([
             ('BOX', (0, 0), (-1, -1), 0.25, colors.black), ('VALIGN', (0, 0), (-1, -1), 'TOP'),
-            ('ALIGN', (0, 0), (0, 0), 'LEFT'), ('FONT', (0, 0), (0, 0), "Helvetica-Bold", 16),
-            ('ALIGN', (1, 0), (1, 0), 'RIGHT'), ('FONT', (1, 0), (1, 0), "Helvetica", 6), ])
+            ('ALIGN', (0, 0), (0, 0), 'LEFT'), ('FONT', (0, 0), (0, 0), utils_polices.FONT_BOLD, 16),
+            ('ALIGN', (1, 0), (1, 0), 'RIGHT'), ('FONT', (1, 0), (1, 0), utils_polices.FONT_NORMAL, 6), ])
         tableau = Table(dataTableau, largeursColonnes)
         tableau.setStyle(style)
         self.story.append(tableau)
@@ -280,7 +280,7 @@ class Impression():
         largeursColonnes = ((self.taille_page[0] - 75))
         style = TableStyle([
             ('LINEBEFORE', (0, 0), (-1, -1), 0.25, colors.black, None, (0.5, 2)), ('VALIGN', (0, 0), (-1, -1), 'TOP'),
-            ('ALIGN', (0, 0), (0, 0), 'LEFT'), ('FONT', (1, 0), (1, 0), "Helvetica", 6), ])
+            ('ALIGN', (0, 0), (0, 0), 'LEFT'), ('FONT', (1, 0), (1, 0), utils_polices.FONT_NORMAL, 6), ])
         tableau = Table(dataTableau, largeursColonnes)
         tableau.setStyle(style)
         self.story.append(tableau)

--- a/noethysweb/core/utils/utils_modeles_documents.py
+++ b/noethysweb/core/utils/utils_modeles_documents.py
@@ -16,7 +16,7 @@ from reportlab.graphics.barcode.code39 import Extended39, Standard39
 from reportlab.graphics.barcode.code93 import Extended93, Standard93
 from reportlab.graphics.barcode.usps import FIM, POSTNET
 from reportlab.graphics.barcode import createBarcodeDrawing
-from core.utils import utils_infos_individus, utils_dates, utils_resolveur_formule
+from core.utils import utils_infos_individus, utils_dates, utils_resolveur_formule, utils_polices
 from core.models import ModeleDocument, Organisateur
 
 
@@ -1125,7 +1125,7 @@ class ObjetPDF():
             if self.categorie == "special":
                 canvas.rect(self.left, self.top, self.width, self.height, self.SetTrait(), self.SetRemplissage())
                 canvas.setFillColorRGB(0, 0, 0)
-                canvas.setFont("Helvetica", 9)
+                canvas.setFont(utils_polices.FONT_NORMAL, 9)
                 canvas.scale(1, -1)
                 canvas.drawString(self.left + 6, -self.top -12, self.nom)
 
@@ -1152,10 +1152,10 @@ class ObjetPDF():
         self.canvas.setFillColor(self.ConvertCouleur(self.fill))
 
     def GetPolice(self):
-        police = "Helvetica"
-        if hasattr(self, "fontWeight") and self.fontWeight == "bold" : police = "Helvetica-Bold"
-        if hasattr(self, "fontStyle") and self.fontStyle == "italic" : police = "Helvetica-Bold"
-        if hasattr(self, "fontWeight") and self.fontWeight == "bold" and self.fontStyle == "italic" : police = "Helvetica-BoldOblique"
+        police = utils_polices.FONT_NORMAL
+        if hasattr(self, "fontWeight") and self.fontWeight == "bold" : police = utils_polices.FONT_BOLD
+        if hasattr(self, "fontStyle") and self.fontStyle == "italic" : police = utils_polices.FONT_BOLD
+        if hasattr(self, "fontWeight") and self.fontWeight == "bold" and self.fontStyle == "italic" : police = utils_polices.FONT_BOLD_OBLIQUE
         return police
 
     def ConvertCouleur(self, couleur=""):

--- a/noethysweb/core/utils/utils_polices.py
+++ b/noethysweb/core/utils/utils_polices.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# Constantes de polices pour l'application
+
+FONT_NORMAL = "Helvetica"
+FONT_BOLD = "Helvetica-Bold"
+FONT_BOLD_OBLIQUE = "Helvetica-BoldOblique"

--- a/noethysweb/cotisations/utils/utils_impression_cotisation.py
+++ b/noethysweb/cotisations/utils/utils_impression_cotisation.py
@@ -5,7 +5,7 @@
 
 import logging
 logger = logging.getLogger(__name__)
-from core.utils import utils_dates, utils_impression, utils_preferences
+from core.utils import utils_dates, utils_impression, utils_preferences, utils_polices
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.platypus import Paragraph, Spacer, Table, TableStyle, PageBreak
 from reportlab.platypus.flowables import DocAssign, Flowable
@@ -19,7 +19,7 @@ class Impression(utils_impression.Impression):
     def Draw(self):
         styleSheet = getSampleStyleSheet()
         styleTexte = styleSheet['BodyText']
-        styleTexte.fontName = "Helvetica"
+        styleTexte.fontName = utils_polices.FONT_NORMAL
         styleTexte.fontSize = 9
         styleTexte.borderPadding = 9
         styleTexte.leading = 12

--- a/noethysweb/facturation/utils/utils_impression_attestation_fiscale.py
+++ b/noethysweb/facturation/utils/utils_impression_attestation_fiscale.py
@@ -5,7 +5,7 @@
 
 import logging
 logger = logging.getLogger(__name__)
-from core.utils import utils_dates, utils_impression, utils_preferences
+from core.utils import utils_dates, utils_impression, utils_preferences, utils_polices
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib import colors
 from reportlab.platypus import Paragraph, Spacer, Table, TableStyle, PageBreak
@@ -39,15 +39,15 @@ class Impression(utils_impression.Impression):
                 dataTableau.append((self.dict_options["texte_titre"],))
                 dataTableau.append(("Période du %s au %s" % (dictValeur["{DATE_DEBUT}"], dictValeur["{DATE_FIN}"]),))
                 style = TableStyle(
-                    [('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (0, 0), "Helvetica-Bold", 19),
-                    ('FONT', (0, 1), (0, 1), "Helvetica", 8), ('LINEBELOW', (0, 0), (0, 0), 0.25, colors.black),
+                    [('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (0, 0), utils_polices.FONT_BOLD, 19),
+                    ('FONT', (0, 1), (0, 1), utils_polices.FONT_NORMAL, 8), ('LINEBELOW', (0, 0), (0, 0), 0.25, colors.black),
                     ('ALIGN', (0, 0), (-1, -1), 'LEFT'), ])
                 tableau = Table(dataTableau, largeursColonnes)
                 tableau.setStyle(style)
                 self.story.append(tableau)
                 self.story.append(Spacer(0, 30))
 
-            paraStyle = ParagraphStyle(name="contenu", fontName="Helvetica", fontSize=11, spaceBefore=0,
+            paraStyle = ParagraphStyle(name="contenu", fontName=utils_polices.FONT_NORMAL, fontSize=11, spaceBefore=0,
                                        spaceafter=0, leftIndent=6, rightIndent=6)
 
             # INTRO
@@ -72,10 +72,10 @@ class Impression(utils_impression.Impression):
             dataTableau.append(("", "Total :", dictValeur["{TOTAL}"]))
 
             style = TableStyle([('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('ALIGN', (0, 0), (-1, -1), 'CENTER'),
-                ('GRID', (0, 0), (-1, -2), 0.25, colors.black), ('FONT', (0, 0), (-1, 0), "Helvetica", 6),
-                ('FONT', (0, 1), (-1, -1), "Helvetica", 10), ('TOPPADDING', (0, 1), (-1, -2), 10), ('BOTTOMPADDING', (0, 1), (-1, -2), 10),
-                ('GRID', (-1, -1), (-1, -1), 0.25, colors.black), ('FONT', (-1, -1), (-1, -1), "Helvetica-Bold", 10),
-                ('ALIGN', (-2, -1), (-2, -1), 'RIGHT'), ('FONT', (-2, -1), (-2, -1), "Helvetica", 6), ])
+                ('GRID', (0, 0), (-1, -2), 0.25, colors.black), ('FONT', (0, 0), (-1, 0), utils_polices.FONT_NORMAL, 6),
+                ('FONT', (0, 1), (-1, -1), utils_polices.FONT_NORMAL, 10), ('TOPPADDING', (0, 1), (-1, -2), 10), ('BOTTOMPADDING', (0, 1), (-1, -2), 10),
+                ('GRID', (-1, -1), (-1, -1), 0.25, colors.black), ('FONT', (-1, -1), (-1, -1), utils_polices.FONT_BOLD, 10),
+                ('ALIGN', (-2, -1), (-2, -1), 'RIGHT'), ('FONT', (-2, -1), (-2, -1), utils_polices.FONT_NORMAL, 6), ])
             tableau = Table(dataTableau, largeursColonnes)
             tableau.setStyle(style)
             self.story.append(tableau)

--- a/noethysweb/facturation/utils/utils_impression_facture.py
+++ b/noethysweb/facturation/utils/utils_impression_facture.py
@@ -12,7 +12,7 @@ from reportlab.lib import colors
 from reportlab.platypus import Paragraph, Spacer, Table, TableStyle, PageBreak
 from reportlab.platypus.flowables import DocAssign
 from core.models import MessageFacture
-from core.utils import utils_dates, utils_impression, utils_preferences
+from core.utils import utils_dates, utils_impression, utils_preferences, utils_polices
 
 
 def PeriodeComplete(mois, annee):
@@ -42,7 +42,7 @@ class Impression(utils_impression.Impression):
         styleSheet = getSampleStyleSheet()
         h3 = styleSheet['Heading3']
         styleTexte = styleSheet['BodyText'] 
-        styleTexte.fontName = "Helvetica"
+        styleTexte.fontName = utils_polices.FONT_NORMAL
         styleTexte.fontSize = 9
         styleTexte.borderPadding = 9
         styleTexte.leading = 12
@@ -89,13 +89,13 @@ class Impression(utils_impression.Impression):
                         dataTableau.append((u"Période du %s au %s" % (utils_dates.ConvertDateENGtoFR(str(dateDebut)), utils_dates.ConvertDateENGtoFR(str(dateFin))),))
                     styles = [
                             ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                            ('FONT', (0, 0), (0, 0), "Helvetica-Bold", int(self.dict_options["taille_texte_titre"])),
+                            ('FONT', (0, 0), (0, 0), utils_polices.FONT_BOLD, int(self.dict_options["taille_texte_titre"])),
                             ('LINEBELOW', (0, 0), (0 ,0), 0.25, colors.black),
                             ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
                             ]
 
                     if self.dict_options["afficher_periode"] == True:
-                        styles.append(('FONT', (0, 1), (0, 1), "Helvetica", int(self.dict_options["taille_texte_periode"])))
+                        styles.append(('FONT', (0, 1), (0, 1), utils_polices.FONT_NORMAL, int(self.dict_options["taille_texte_periode"])))
                     tableau = Table(dataTableau, largeursColonnes)
                     tableau.setStyle(TableStyle(styles))
                     self.story.append(tableau)
@@ -103,7 +103,7 @@ class Impression(utils_impression.Impression):
 
                 if self.dict_options["texte_introduction"] != "":
                     paraStyle = ParagraphStyle(name="introduction",
-                                          fontName="Helvetica",
+                                          fontFace=utils_polices.FONT_NORMAL,
                                           fontSize=int(self.dict_options["taille_texte_introduction"]),
                                           leading=14,
                                           spaceBefore=0,
@@ -176,7 +176,7 @@ class Impression(utils_impression.Impression):
                         
                         # Insertion du nom de l'individu
                         paraStyle = ParagraphStyle(name="individu",
-                                              fontName="Helvetica",
+                                              fontFace=utils_polices.FONT_NORMAL,
                                               fontSize=int(self.dict_options["taille_texte_individu"]),
                                               leading=int(self.dict_options["taille_texte_individu"]+2),
                                               spaceBefore=0,
@@ -187,7 +187,7 @@ class Impression(utils_impression.Impression):
                         tableau = Table(dataTableau, [self.taille_cadre[2],])
                         listeStyles = [
                                 ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                                ('FONT', (0, 0), (-1, -1), "Helvetica", int(self.dict_options["taille_texte_individu"])),
+                                ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, int(self.dict_options["taille_texte_individu"])),
                                 ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
                                 ('BACKGROUND', (0, 0), (-1, 0), couleurFond),
                                 ]
@@ -209,7 +209,7 @@ class Impression(utils_impression.Impression):
                                 tableau = Table(dataTableau, [self.taille_cadre[2],])
                                 listeStyles = [
                                     ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                                    ('FONT', (0, 0), (-1, -1), "Helvetica", int(self.dict_options["taille_texte_activite"])),
+                                    ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, int(self.dict_options["taille_texte_activite"])),
                                     ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
                                     ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
                                     ('BACKGROUND', (0, 0), (-1, 0), couleurFondActivite),
@@ -219,20 +219,20 @@ class Impression(utils_impression.Impression):
 
                             # Style de paragraphe normal
                             paraStyle = ParagraphStyle(name="prestation",
-                                          fontName="Helvetica",
+                                          fontFace=utils_polices.FONT_NORMAL,
                                           fontSize=int(self.dict_options["taille_texte_prestation"]),
                                           leading=int(self.dict_options["taille_texte_prestation"]),
                                           spaceBefore=0,
                                           spaceAfter=0)
 
                             paraLabelsColonnes = ParagraphStyle(name="paraLabelsColonnes",
-                                          fontName="Helvetica",
+                                          fontFace=utils_polices.FONT_NORMAL,
                                           fontSize=int(self.dict_options["taille_texte_noms_colonnes"]),
                                           leading=int(self.dict_options["taille_texte_noms_colonnes"]),
                                           spaceBefore=0,
                                           spaceAfter=0)
 
-                            paraStyleDatesForfait = ParagraphStyle(name="prestation", fontName="Helvetica", fontSize=int(self.dict_options["taille_texte_prestation"]),
+                            paraStyleDatesForfait = ParagraphStyle(name="prestation", fontFace=utils_polices.FONT_NORMAL, fontSize=int(self.dict_options["taille_texte_prestation"]),
                                                                    leading=int(self.dict_options["taille_texte_prestation"]), spaceBefore=2, spaceAfter=0)
 
                             if self.dict_options["affichage_prestations"] != "0":
@@ -337,7 +337,7 @@ class Impression(utils_impression.Impression):
                                 listeDates.sort() 
                                 
                                 paraStyle = ParagraphStyle(name="prestation",
-                                              fontName="Helvetica",
+                                              fontFace=utils_polices.FONT_NORMAL,
                                               fontSize=int(self.dict_options["taille_texte_prestation"]),
                                               leading=int(self.dict_options["taille_texte_prestation"]),
                                               spaceBefore=0,
@@ -456,7 +456,7 @@ class Impression(utils_impression.Impression):
                             tableau = Table(dataTableau, largeursColonnes)
                             listeStyles = [
                                 ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                                ('FONT', (0, 0), (-1, -1), "Helvetica", int(self.dict_options["taille_texte_prestation"])),
+                                ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, int(self.dict_options["taille_texte_prestation"])),
                                 ('GRID', (0, 0), (-1,-1), 0.25, colors.black), 
                                 ('ALIGN', (0, 0), (-1, -1), 'CENTRE'),
                                 ('ALIGN', (1, 0), (1, -1), 'LEFT'),
@@ -486,14 +486,14 @@ class Impression(utils_impression.Impression):
                         
                         listeStyles = [
                                 ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                                ('FONT', (0, 0), (-1, -1), "Helvetica", int(self.dict_options["taille_texte_prestation"])),
+                                ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, int(self.dict_options["taille_texte_prestation"])),
                                 ('GRID', (-1, -1), (-1,-1), 0.25, colors.black), 
                                 ('ALIGN', (-1, -1), (-1, -1), 'CENTRE'),
                                 ('BACKGROUND', (-1, -1), (-1, -1), couleurFond), 
                                 ('TOPPADDING', (0, 0), (-1, -1), 1), 
                                 ('BOTTOMPADDING', (0, 0), (-1, -1), 3),
                                 ('SPAN', (0, -1), (-2, -1)), # Fusion de la dernière ligne pour le texte_prestations_anterieures
-                                ('FONT', (0, -1), (0, -1), "Helvetica", int(self.dict_options["taille_texte_prestations_anterieures"])),
+                                ('FONT', (0, -1), (0, -1), utils_polices.FONT_NORMAL, int(self.dict_options["taille_texte_prestations_anterieures"])),
                             ]
                             
                         # Création du tableau
@@ -505,7 +505,7 @@ class Impression(utils_impression.Impression):
                 # Intégration des messages, des reports et des qf
                 listeMessages = []
                 paraStyle = ParagraphStyle(name="message",
-                                          fontName="Helvetica",
+                                          fontFace=utils_polices.FONT_NORMAL,
                                           fontSize=int(self.dict_options["taille_texte_messages"]),
                                           leading=int(self.dict_options["taille_texte_messages"]),
                                           spaceAfter=2)
@@ -630,12 +630,12 @@ class Impression(utils_impression.Impression):
                         ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), 
 
                         # Lignes Période, avoir, impayés
-                        ('FONT', (1, 0), (1, -2), "Helvetica", 8),
-                        ('FONT', (2, 0), (2, -2), "Helvetica-Bold", 8),
+                        ('FONT', (1, 0), (1, -2), utils_polices.FONT_NORMAL, 8),
+                        ('FONT', (2, 0), (2, -2), utils_polices.FONT_BOLD, 8),
                         
                         # Ligne Reste à régler
-                        ('FONT', (1, -1), (1, -1), "Helvetica-Bold", int(self.dict_options["taille_texte_labels_totaux"])),
-                        ('FONT', (2, -1), (2, -1), "Helvetica-Bold", int(self.dict_options["taille_texte_montants_totaux"])),
+                        ('FONT', (1, -1), (1, -1), utils_polices.FONT_BOLD, int(self.dict_options["taille_texte_labels_totaux"])),
+                        ('FONT', (2, -1), (2, -1), utils_polices.FONT_BOLD, int(self.dict_options["taille_texte_montants_totaux"])),
                         
                         ('GRID', (2, 0), (2, -1), 0.25, colors.black),
                         
@@ -648,7 +648,7 @@ class Impression(utils_impression.Impression):
                 
                 if self.mode == "facture" and len(listeMessages) > 0:
                     #style.append( ('BACKGROUND', (0, 0), (0, 0), couleurFondActivite) )
-                    style.append( ('FONT', (0, 0), (0, -1), "Helvetica", 8))
+                    style.append( ('FONT', (0, 0), (0, -1), utils_polices.FONT_NORMAL, 8))
                     style.append( ('VALIGN', (0, 0), (0, -1), 'TOP'))
                     
                 tableau = Table(dataTableau, largeursColonnes)
@@ -658,7 +658,7 @@ class Impression(utils_impression.Impression):
                 # ------------------------- PRELEVEMENTS --------------------
                 if self.dict_options.get("afficher_avis_prelevements", False) and dictValeur.get("prelevement", False):
                     paraStyle = ParagraphStyle(name="intro",
-                          fontName="Helvetica",
+                          fontFace=utils_polices.FONT_NORMAL,
                           fontSize=8,
                           leading=11,
                           spaceBefore=2,
@@ -672,7 +672,7 @@ class Impression(utils_impression.Impression):
                 if self.dict_options["texte_conclusion"] != "":
                     self.story.append(Spacer(0, 20))
                     paraStyle = ParagraphStyle(name="conclusion",
-                                          fontName="Helvetica",
+                                          fontFace=utils_polices.FONT_NORMAL,
                                           fontSize=int(self.dict_options["taille_texte_conclusion"]),
                                           leading=14,
                                           spaceBefore=0,

--- a/noethysweb/facturation/utils/utils_impression_lot_pes.py
+++ b/noethysweb/facturation/utils/utils_impression_lot_pes.py
@@ -63,7 +63,7 @@ class Impression(utils_impression.Impression):
         # Préparation des polices
         style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
         style_centre = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceAfter=0, leading=9)
-        style_titre = ParagraphStyle(name="titre", fontName="Helvetica-bold", alignment=1, fontSize=11, spaceAfter=0, leading=11)
+        style_titre = ParagraphStyle(name="titre", fontName="Helvetica-Bold", alignment=1, fontSize=11, spaceAfter=0, leading=11)
 
         # Création du titre du document
         self.Insert_header()

--- a/noethysweb/facturation/utils/utils_impression_lot_pes.py
+++ b/noethysweb/facturation/utils/utils_impression_lot_pes.py
@@ -11,7 +11,7 @@ from reportlab.platypus import Spacer, Paragraph, Table, TableStyle
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib import colors
 from core.models import PesLot, PesPiece, Prestation
-from core.utils import utils_dates, utils_impression, utils_texte
+from core.utils import utils_dates, utils_impression, utils_texte, utils_polices
 
 
 class Impression(utils_impression.Impression):
@@ -61,9 +61,9 @@ class Impression(utils_impression.Impression):
         )
 
         # Préparation des polices
-        style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
-        style_centre = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceAfter=0, leading=9)
-        style_titre = ParagraphStyle(name="titre", fontName="Helvetica-Bold", alignment=1, fontSize=11, spaceAfter=0, leading=11)
+        style_defaut = ParagraphStyle(name="defaut", fontName=utils_polices.FONT_NORMAL, fontSize=7, spaceAfter=0, leading=9)
+        style_centre = ParagraphStyle(name="centre", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=7, spaceAfter=0, leading=9)
+        style_titre = ParagraphStyle(name="titre", fontName=utils_polices.FONT_BOLD, alignment=1, fontSize=11, spaceAfter=0, leading=11)
 
         # Création du titre du document
         self.Insert_header()
@@ -149,7 +149,7 @@ class Impression(utils_impression.Impression):
         # Finalisation du tableau
         style = TableStyle([
             ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-            ("FONT", (0, 0), (-1, -1), "Helvetica", 7),
+            ("FONT", (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
             ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
             ("ALIGN", (0, 0), (-1, -1), "CENTRE"),
         ])
@@ -195,7 +195,7 @@ class Impression(utils_impression.Impression):
         tableau = Table(dataTableau, [195, 65, 65, 65, 65, 65])
         tableau.setStyle(TableStyle([
             ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-            ("FONT", (0, 0), (-1, -1), "Helvetica", 7),
+            ("FONT", (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
             ("GRID", (0, 0), (-1, -2), 0.25, colors.black),
             ("GRID", (-2, -1), (-1, -1), 0.25, colors.black),
             ("ALIGN", (0, 0), (-1, -1), "CENTRE"),

--- a/noethysweb/facturation/utils/utils_impression_lot_prelevements.py
+++ b/noethysweb/facturation/utils/utils_impression_lot_prelevements.py
@@ -58,7 +58,7 @@ class Impression(utils_impression.Impression):
         # Préparation des polices
         style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
         style_centre = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceAfter=0, leading=9)
-        style_titre = ParagraphStyle(name="titre", fontName="Helvetica-bold", alignment=1, fontSize=11, spaceAfter=0, leading=11)
+        style_titre = ParagraphStyle(name="titre", fontName="Helvetica-Bold", alignment=1, fontSize=11, spaceAfter=0, leading=11)
 
         # Création du titre du document
         self.Insert_header()

--- a/noethysweb/facturation/utils/utils_impression_lot_prelevements.py
+++ b/noethysweb/facturation/utils/utils_impression_lot_prelevements.py
@@ -11,7 +11,7 @@ from reportlab.platypus import Spacer, Paragraph, Table, TableStyle
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib import colors
 from core.models import PrelevementsLot, Prelevements, Prestation
-from core.utils import utils_impression, utils_texte
+from core.utils import utils_dates, utils_impression, utils_texte, utils_polices
 
 
 class Impression(utils_impression.Impression):
@@ -56,9 +56,9 @@ class Impression(utils_impression.Impression):
         stats = pieces.aggregate(total=Sum("montant"), nbre=Count("idprelevement"))
 
         # Préparation des polices
-        style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
-        style_centre = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceAfter=0, leading=9)
-        style_titre = ParagraphStyle(name="titre", fontName="Helvetica-Bold", alignment=1, fontSize=11, spaceAfter=0, leading=11)
+        style_defaut = ParagraphStyle(name="defaut", fontName=utils_polices.FONT_NORMAL, fontSize=7, spaceAfter=0, leading=9)
+        style_centre = ParagraphStyle(name="centre", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=7, spaceAfter=0, leading=9)
+        style_titre = ParagraphStyle(name="titre", fontName=utils_polices.FONT_BOLD, alignment=1, fontSize=11, spaceAfter=0, leading=11)
 
         # Création du titre du document
         self.Insert_header()
@@ -135,7 +135,7 @@ class Impression(utils_impression.Impression):
         # Finalisation du tableau
         style = TableStyle([
             ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-            ("FONT", (0, 0), (-1, -1), "Helvetica", 7),
+            ("FONT", (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
             ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
             ("ALIGN", (0, 0), (-1, -1), "CENTRE"),
         ])
@@ -181,7 +181,7 @@ class Impression(utils_impression.Impression):
         tableau = Table(dataTableau, [195, 65, 65, 65, 65, 65])
         tableau.setStyle(TableStyle([
             ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-            ("FONT", (0, 0), (-1, -1), "Helvetica", 7),
+            ("FONT", (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
             ("GRID", (0, 0), (-1, -2), 0.25, colors.black),
             ("GRID", (-2, -1), (-1, -1), 0.25, colors.black),
             ("ALIGN", (0, 0), (-1, -1), "CENTRE"),

--- a/noethysweb/facturation/utils/utils_impression_prestations.py
+++ b/noethysweb/facturation/utils/utils_impression_prestations.py
@@ -11,7 +11,7 @@ from reportlab.platypus import Spacer, Paragraph, Table, TableStyle
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib import colors
 from core.models import Prestation, Activite
-from core.utils import utils_impression, utils_texte
+from core.utils import utils_impression, utils_texte, utils_polices
 
 
 class Impression(utils_impression.Impression):
@@ -61,8 +61,8 @@ class Impression(utils_impression.Impression):
                 dict_prestations_famille[famille].append(dict_prestation)
 
         # Préparation des polices
-        style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
-        style_centre = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceAfter=0, leading=9)
+        style_defaut = ParagraphStyle(name="defaut", fontName=utils_polices.FONT_NORMAL, fontSize=7, spaceAfter=0, leading=9)
+        style_centre = ParagraphStyle(name="centre", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=7, spaceAfter=0, leading=9)
 
         # Création du titre du document
         self.Insert_header()
@@ -107,7 +107,7 @@ class Impression(utils_impression.Impression):
         # Finalisation du tableau
         style = TableStyle([
             ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-            ("FONT", (0, 0), (-1, -1), "Helvetica", 7),
+            ("FONT", (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
             ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
             ("ALIGN", (0, 0), (-1, -1), "CENTRE"),
         ])
@@ -165,7 +165,7 @@ class Impression(utils_impression.Impression):
         tableau = Table(dataTableau, largeurs_colonnes)
         tableau.setStyle(TableStyle([
             ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-            ("FONT", (0, 0), (-1, -1), "Helvetica", 7),
+            ("FONT", (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
             ("GRID", (0, 0), (-1, -2), 0.25, colors.black),
             ("GRID", (-2, -1), (-1, -1), 0.25, colors.black),
             ("ALIGN", (0, 0), (-1, -1), "CENTRE"),

--- a/noethysweb/facturation/utils/utils_impression_rappel.py
+++ b/noethysweb/facturation/utils/utils_impression_rappel.py
@@ -9,7 +9,7 @@ from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib import colors
 from reportlab.platypus import Paragraph, Spacer, Table, TableStyle, PageBreak
 from reportlab.platypus.flowables import DocAssign
-from core.utils import utils_dates, utils_impression, utils_texte
+from core.utils import utils_dates, utils_impression, utils_texte, utils_polices
 
 
 class Impression(utils_impression.Impression):
@@ -39,15 +39,15 @@ class Impression(utils_impression.Impression):
                 dataTableau.append((dictValeur["titre"],))
                 dataTableau.append(("Situation au %s" % utils_dates.ConvertDateENGtoFR(dictValeur["date_reference"]),))
                 style = TableStyle(
-                    [('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (0, 0), "Helvetica-Bold", 19),
-                        ('FONT', (0, 1), (0, 1), "Helvetica", 8), ('LINEBELOW', (0, 0), (0, 0), 0.25, colors.black),
+                    [('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (0, 0), utils_polices.FONT_BOLD, 19),
+                        ('FONT', (0, 1), (0, 1), utils_polices.FONT_NORMAL, 8), ('LINEBELOW', (0, 0), (0, 0), 0.25, colors.black),
                         ('ALIGN', (0, 0), (-1, -1), 'LEFT'), ])
                 tableau = Table(dataTableau, largeursColonnes)
                 tableau.setStyle(style)
                 self.story.append(tableau)
                 self.story.append(Spacer(0, 30))
 
-                paraStyle = ParagraphStyle(name="contenu", fontName="Helvetica", fontSize=11, spaceBefore=0,
+                paraStyle = ParagraphStyle(name="contenu", fontName=utils_polices.FONT_NORMAL, fontSize=11, spaceBefore=0,
                                            spaceafter=0, leftIndent=6, rightIndent=6)
 
                 # Conversion html en str si nécessaire

--- a/noethysweb/facturation/utils/utils_impression_recap_factures.py
+++ b/noethysweb/facturation/utils/utils_impression_recap_factures.py
@@ -11,7 +11,7 @@ from reportlab.platypus import Spacer, Paragraph, Table, TableStyle
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib import colors
 from core.models import Facture, Prestation, Prelevements, PesPiece
-from core.utils import utils_impression, utils_texte
+from core.utils import utils_dates, utils_impression, utils_texte, utils_polices
 
 
 class Impression(utils_impression.Impression):
@@ -65,9 +65,9 @@ class Impression(utils_impression.Impression):
         stats = factures.aggregate(total=Sum("total"), nbre=Count("idfacture"))
 
         # Préparation des polices
-        style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
-        style_centre = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceAfter=0, leading=9)
-        style_titre = ParagraphStyle(name="titre", fontName="Helvetica-Bold", alignment=1, fontSize=11, spaceAfter=0, leading=11)
+        style_defaut = ParagraphStyle(name="defaut", fontName=utils_polices.FONT_NORMAL, fontSize=7, spaceAfter=0, leading=9)
+        style_centre = ParagraphStyle(name="centre", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=7, spaceAfter=0, leading=9)
+        style_titre = ParagraphStyle(name="titre", fontName=utils_polices.FONT_BOLD, alignment=1, fontSize=11, spaceAfter=0, leading=11)
 
         # Création du titre du document
         self.Insert_header()
@@ -136,7 +136,7 @@ class Impression(utils_impression.Impression):
         # Finalisation du tableau
         style = TableStyle([
             ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-            ("FONT", (0, 0), (-1, -1), "Helvetica", 7),
+            ("FONT", (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
             ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
             ("ALIGN", (0, 0), (-1, -1), "CENTRE"),
         ])
@@ -182,7 +182,7 @@ class Impression(utils_impression.Impression):
         tableau = Table(dataTableau, [195, 65, 65, 65, 65, 65])
         tableau.setStyle(TableStyle([
             ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-            ("FONT", (0, 0), (-1, -1), "Helvetica", 7),
+            ("FONT", (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
             ("GRID", (0, 0), (-1, -2), 0.25, colors.black),
             ("GRID", (-2, -1), (-1, -1), 0.25, colors.black),
             ("ALIGN", (0, 0), (-1, -1), "CENTRE"),

--- a/noethysweb/facturation/utils/utils_impression_recap_factures.py
+++ b/noethysweb/facturation/utils/utils_impression_recap_factures.py
@@ -67,7 +67,7 @@ class Impression(utils_impression.Impression):
         # Préparation des polices
         style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
         style_centre = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceAfter=0, leading=9)
-        style_titre = ParagraphStyle(name="titre", fontName="Helvetica-bold", alignment=1, fontSize=11, spaceAfter=0, leading=11)
+        style_titre = ParagraphStyle(name="titre", fontName="Helvetica-Bold", alignment=1, fontSize=11, spaceAfter=0, leading=11)
 
         # Création du titre du document
         self.Insert_header()

--- a/noethysweb/fiche_famille/utils/utils_impression_recu.py
+++ b/noethysweb/fiche_famille/utils/utils_impression_recu.py
@@ -5,7 +5,7 @@
 
 import logging
 logger = logging.getLogger(__name__)
-from core.utils import utils_dates, utils_impression, utils_preferences, utils_conversion
+from core.utils import utils_dates, utils_impression, utils_preferences, utils_conversion, utils_polices
 from reportlab.platypus import Paragraph, Spacer, Table, TableStyle
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.lib import colors
@@ -19,7 +19,7 @@ class Impression(utils_impression.Impression):
         styleSheet = getSampleStyleSheet()
         h3 = styleSheet['Heading3']
         styleTexte = styleSheet['BodyText']
-        styleTexte.fontName = "Helvetica"
+        styleTexte.fontName = utils_polices.FONT_NORMAL
         styleTexte.fontSize = 9
         styleTexte.borderPadding = 9
         styleTexte.leading = 12
@@ -29,8 +29,8 @@ class Impression(utils_impression.Impression):
         largeursColonnes = [self.taille_cadre[2], ]
         dataTableau.append(("Reçu de règlement",))
         dataTableau.append(("",))
-        style = TableStyle([('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (0, 0), "Helvetica-Bold", 19),
-            ('FONT', (0, 1), (0, 1), "Helvetica", 8), ('LINEBELOW', (0, 0), (0, 0), 0.25, colors.black),
+        style = TableStyle([('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (0, 0), utils_polices.FONT_BOLD, 19),
+            ('FONT', (0, 1), (0, 1), utils_polices.FONT_NORMAL, 8), ('LINEBELOW', (0, 0), (0, 0), 0.25, colors.black),
             ('ALIGN', (0, 0), (-1, -1), 'LEFT'), ])
         tableau = Table(dataTableau, largeursColonnes)
         tableau.setStyle(style)
@@ -38,7 +38,7 @@ class Impression(utils_impression.Impression):
         self.story.append(Spacer(0, 10))
 
         # TEXTE D'INTRODUCTION
-        paraStyleIntro = ParagraphStyle(name="intro", fontName="Helvetica", fontSize=11, leading=14, spaceBefore=0,
+        paraStyleIntro = ParagraphStyle(name="intro", fontName=utils_polices.FONT_NORMAL, fontSize=11, leading=14, spaceBefore=0,
                                         spaceafter=0, leftIndent=0, rightIndent=0, alignment=0, )
 
         if self.dict_donnees["intro"]:
@@ -53,7 +53,7 @@ class Impression(utils_impression.Impression):
         dataTableau = []
         largeursColonnes = [120, self.taille_cadre[2]-120]
 
-        paraStyle = ParagraphStyle(name="detail", fontName="Helvetica-Bold", fontSize=9)
+        paraStyle = ParagraphStyle(name="detail", fontName=utils_polices.FONT_BOLD, fontSize=9)
         dataTableau.append(("Caractéristiques du règlement", ""))
         monnaie = utils_preferences.Get_monnaie()
         montantEnLettres = utils_conversion.trad(self.dict_donnees["{MONTANT_REGLEMENT}"]).strip()
@@ -69,12 +69,12 @@ class Impression(utils_impression.Impression):
 
         style = TableStyle([
             ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-            ('FONT', (0, 0), (0, -1), "Helvetica", 9),
-            ('FONT', (1, 0), (1, -1), "Helvetica-Bold", 9),
+            ('FONT', (0, 0), (0, -1), utils_polices.FONT_NORMAL, 9),
+            ('FONT', (1, 0), (1, -1), utils_polices.FONT_BOLD, 9),
             ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
             ('ALIGN', (0, 1), (0, -1), 'RIGHT'),
             ('ALIGN', (1, 1), (1, -1), 'LEFT'),
-            ('FONT', (0, 0), (0, 0), "Helvetica", 7), ('SPAN', (0, 0), (-1, 0)),
+            ('FONT', (0, 0), (0, 0), utils_polices.FONT_NORMAL, 7), ('SPAN', (0, 0), (-1, 0)),
             ('BACKGROUND', (0, 0), (-1, 0), couleurFond),
         ])
         tableau = Table(dataTableau, largeursColonnes)
@@ -94,7 +94,7 @@ class Impression(utils_impression.Impression):
             largeur_temp = self.taille_cadre[2] - 50 - 50
             largeursColonnes = [50, largeur_temp/3+5, largeur_temp/3-10, largeur_temp/3+5, 50]
 
-            paraStyle = ParagraphStyle(name="detail", fontName="Helvetica", fontSize=7, leading=7, spaceBefore=0, spaceAfter=0, )
+            paraStyle = ParagraphStyle(name="detail", fontName=utils_polices.FONT_NORMAL, fontSize=7, leading=7, spaceBefore=0, spaceAfter=0, )
 
             for prestation in prestations:
                 date = utils_dates.ConvertDateToFR(prestation["prestation__date"])
@@ -110,10 +110,10 @@ class Impression(utils_impression.Impression):
             style = TableStyle([
                 ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
                 ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
-                ('FONT', (0, 0), (-1, -1), "Helvetica", 7),
+                ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
                 ('TOPPADDING', (0, 1), (-1, -1), 1),
                 ('BOTTOMPADDING', (0, 1), (-1, -1), 3),
-                ('FONT', (0, 0), (-1, 0), "Helvetica", 7),
+                ('FONT', (0, 0), (-1, 0), utils_polices.FONT_NORMAL, 7),
                 ('BACKGROUND', (0, 0), (-1, 0), couleurFond),
                 ('ALIGN', (0, 0), (-1, 0), 'CENTER'),
             ])

--- a/noethysweb/fiche_famille/utils/utils_impression_releve_prestations.py
+++ b/noethysweb/fiche_famille/utils/utils_impression_releve_prestations.py
@@ -9,7 +9,7 @@ from django.db.models import Sum
 from reportlab.platypus import Paragraph, Spacer, Table, TableStyle
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib import colors
-from core.utils import utils_dates, utils_impression, utils_preferences
+from core.utils import utils_dates, utils_impression, utils_preferences, utils_polices
 from core.models import Prestation, Ventilation, Facture, Famille, Consommation
 
 
@@ -45,7 +45,7 @@ class Impression(utils_impression.Impression):
             consommations[conso.prestation_id].append(conso)
 
         # Nom de la famille
-        self.story.append(Paragraph("<para align='center'>%s</para>" % famille.nom, ParagraphStyle(name="standard", fontName="Helvetica-Bold", fontSize=10, leading=10, spaceAfter=0)))
+        self.story.append(Paragraph("<para align='center'>%s</para>" % famille.nom, ParagraphStyle(name="standard", fontName=utils_polices.FONT_BOLD, fontSize=10, leading=10, spaceAfter=0)))
         self.story.append(Spacer(0,20))
 
         # Création des périodes
@@ -73,8 +73,8 @@ class Impression(utils_impression.Impression):
 
                 listeStyles = [
                     ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                    ('GRID', (0, 0), (-1, -1), 0.25, colors.black), ('FONT', (0, 0), (-1, -1), "Helvetica", 9),
-                    ('ALIGN', (0, 0), (-1, -1), 'LEFT'), ('FONT', (0, 1), (-1, -1), "Helvetica", 8),
+                    ('GRID', (0, 0), (-1, -1), 0.25, colors.black), ("FONT", (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 9),
+                    ('ALIGN', (0, 0), (-1, -1), 'LEFT'), ('FONT', (0, 1), (-1, -1), utils_polices.FONT_NORMAL, 8),
                     ('BACKGROUND', (-1, -1), (-1, -1), couleur_fond_titre),
                 ]
 
@@ -89,7 +89,7 @@ class Impression(utils_impression.Impression):
                 else:
                     largeursColonnes = [370, 50, 50, 50]
                     dataTableau.append([label_regroupement, "Total dû", "Réglé", "Reste dû"])
-                paraStyle = ParagraphStyle(name="standard", fontName="Helvetica", fontSize=8, leading=10, spaceAfter=0)
+                paraStyle = ParagraphStyle(name="standard", fontName=utils_polices.FONT_NORMAL, fontSize=8, leading=10, spaceAfter=0)
 
                 total_du = decimal.Decimal(0)
                 total_regle = decimal.Decimal(0)
@@ -209,8 +209,8 @@ class Impression(utils_impression.Impression):
 
                 listeStyles = [
                     ('VALIGN', (0, 0), (-1, -1), 'TOP'), ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
-                    ('FONT', (0, 0), (-1, 0), "Helvetica", 6), ('ALIGN', (0, 0), (-1, 0), 'CENTRE'),
-                    ('FONT', (0, 1), (-1, 1), "Helvetica", 8),
+                    ('FONT', (0, 0), (-1, 0), utils_polices.FONT_NORMAL, 6), ('ALIGN', (0, 0), (-1, 0), 'CENTRE'),
+                    ('FONT', (0, 1), (-1, 1), utils_polices.FONT_NORMAL, 8),
                 ]
 
                 if dataTableau:
@@ -232,7 +232,7 @@ class Impression(utils_impression.Impression):
 
                     listeStyles = [
                         ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                        ('FONT', (0, 0), (-1, -1), "Helvetica", 8), ('GRID', (1, -1), (-1, -1), 0.25, colors.black),
+                        ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 8), ('GRID', (1, -1), (-1, -1), 0.25, colors.black),
                         ('ALIGN', (-1, -1), (-1, -1), 'CENTRE'),
                         ('BACKGROUND', (-1, 0), (-1, -1), couleur_fond_titre),
                     ]
@@ -255,8 +255,8 @@ class Impression(utils_impression.Impression):
 
                 listeStyles = [
                     ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                    ('GRID', (0, 0), (-1, -1), 0.25, colors.black), ('FONT', (0, 0), (-1, -1), "Helvetica", 9),
-                    ('ALIGN', (0, 0), (-1, -1), 'LEFT'), ('FONT', (0, 1), (-1, -1), "Helvetica", 8),
+                    ('GRID', (0, 0), (-1, -1), 0.25, colors.black), ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 9),
+                    ('ALIGN', (0, 0), (-1, -1), 'LEFT'), ('FONT', (0, 1), (-1, -1), utils_polices.FONT_NORMAL, 8),
                     ('BACKGROUND', (-1, -1), (-1, -1), couleur_fond_titre),
                 ]
 
@@ -268,7 +268,7 @@ class Impression(utils_impression.Impression):
                 largeursColonnes = [60, 110, 200, 50, 50, 50]
                 dataTableau.append(["Date d'édition", "Numéro", "Période", "Total dû", "Réglé", "Reste dû"])
 
-                paraStyle = ParagraphStyle(name="standard", fontName="Helvetica", fontSize=8, leading=10, spaceAfter=0)
+                paraStyle = ParagraphStyle(name="standard", fontName=utils_polices.FONT_NORMAL, fontSize=8, leading=10, spaceAfter=0)
 
                 total_du = decimal.Decimal(0)
                 total_regle = decimal.Decimal(0)
@@ -320,8 +320,8 @@ class Impression(utils_impression.Impression):
 
                 listeStyles = [
                     ('VALIGN', (0, 0), (-1, -1), 'TOP'), ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
-                    ('FONT', (0, 0), (-1, 0), "Helvetica", 6), ('ALIGN', (0, 0), (-1, 0), 'CENTRE'),
-                    ('FONT', (0, 1), (-1, 1), "Helvetica", 8),
+                    ('FONT', (0, 0), (-1, 0), utils_polices.FONT_NORMAL, 6), ('ALIGN', (0, 0), (-1, 0), 'CENTRE'),
+                    ('FONT', (0, 1), (-1, 1), utils_polices.FONT_NORMAL, 8),
                 ]
 
                 if dataTableau:
@@ -341,7 +341,7 @@ class Impression(utils_impression.Impression):
 
                     listeStyles = [
                         ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                        ('FONT', (0, 0), (-1, -1), "Helvetica", 8), ('GRID', (1, -1), (-1, -1), 0.25, colors.black),
+                        ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 8), ('GRID', (1, -1), (-1, -1), 0.25, colors.black),
                         ('ALIGN', (-1, -1), (-1, -1), 'CENTRE'),
                         ('BACKGROUND', (-1, 0), (-1, -1), couleur_fond_titre),
                     ]
@@ -367,7 +367,7 @@ class Impression(utils_impression.Impression):
         self.dict_donnees["{DATE_EDITION_RELEVE}"] = utils_dates.ConvertDateToFR(datetime.date.today())
 
         listeStyles = [
-            ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (-1, -1), "Helvetica", 8),
+            ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'), ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 8),
             ('GRID', (1, -1), (-1, -1), 0.25, colors.black), ('ALIGN', (-1, -1), (-1, -1), 'CENTRE'),
             ('BACKGROUND', (-1, 0), (-1, -1), couleur_fond_titre),
         ]

--- a/noethysweb/fiche_famille/utils/utils_impression_releve_prestations.py
+++ b/noethysweb/fiche_famille/utils/utils_impression_releve_prestations.py
@@ -45,7 +45,7 @@ class Impression(utils_impression.Impression):
             consommations[conso.prestation_id].append(conso)
 
         # Nom de la famille
-        self.story.append(Paragraph("<para align='center'>%s</para>" % famille.nom, ParagraphStyle(name="standard", fontName="Helvetica-bold", fontSize=10, leading=10, spaceAfter=0)))
+        self.story.append(Paragraph("<para align='center'>%s</para>" % famille.nom, ParagraphStyle(name="standard", fontName="Helvetica-Bold", fontSize=10, leading=10, spaceAfter=0)))
         self.story.append(Spacer(0,20))
 
         # Création des périodes

--- a/noethysweb/fiche_individu/utils/utils_impression_inscription.py
+++ b/noethysweb/fiche_individu/utils/utils_impression_inscription.py
@@ -5,7 +5,7 @@
 
 import logging
 logger = logging.getLogger(__name__)
-from core.utils import utils_dates, utils_impression, utils_preferences
+from core.utils import utils_dates, utils_impression, utils_preferences, utils_polices
 from reportlab.lib.styles import getSampleStyleSheet, ParagraphStyle
 from reportlab.platypus import Paragraph, Spacer, Table, TableStyle, PageBreak
 from reportlab.platypus.flowables import DocAssign, Flowable
@@ -19,7 +19,7 @@ class Impression(utils_impression.Impression):
     def Draw(self):
         styleSheet = getSampleStyleSheet()
         styleTexte = styleSheet['BodyText']
-        styleTexte.fontName = "Helvetica"
+        styleTexte.fontName = utils_polices.FONT_NORMAL
         styleTexte.fontSize = 9
         styleTexte.borderPadding = 9
         styleTexte.leading = 12
@@ -47,8 +47,8 @@ class Impression(utils_impression.Impression):
                 dataTableau.append((u"",))
                 style = TableStyle([
                     ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                    ('FONT', (0, 0), (0, 0), "Helvetica-Bold", 19),
-                    ('FONT', (0, 1), (0, 1), "Helvetica", 8),
+                    ('FONT', (0, 0), (0, 0), utils_polices.FONT_BOLD, 19),
+                    ('FONT', (0, 1), (0, 1), utils_polices.FONT_NORMAL, 8),
                     ('LINEBELOW', (0, 0), (0, 0), 0.25, colors.black),
                     ('ALIGN', (0, 0), (-1, -1), 'LEFT'),
                 ])
@@ -59,7 +59,7 @@ class Impression(utils_impression.Impression):
 
                 # TEXTE D'INTRODUCTION
                 # paraStyleIntro = ParagraphStyle(name="intro",
-                #                                 fontName="Helvetica",
+                #                                 fontName=utils_polices.FONT_NORMAL,
                 #                                 fontSize=11,
                 #                                 leading=14,
                 #                                 spaceBefore=0,
@@ -77,7 +77,7 @@ class Impression(utils_impression.Impression):
                 # ------------------- TABLEAU CONTENU -----------------
                 dataTableau = []
                 largeursColonnes = [100, self.taille_cadre[2] - 100]
-                paraStyle = ParagraphStyle(name="detail", fontName="Helvetica-Bold", fontSize=9)
+                paraStyle = ParagraphStyle(name="detail", fontName=utils_polices.FONT_BOLD, fontSize=9)
                 dataTableau.append(("Nom", Paragraph(dictValeur["{INDIVIDU_NOM}"], paraStyle)))
                 dataTableau.append(("Prénom", Paragraph(dictValeur["{INDIVIDU_PRENOM}"] or "", paraStyle)))
                 dataTableau.append(("Activité", Paragraph(dictValeur["{ACTIVITE_NOM_LONG}"], paraStyle)))
@@ -88,7 +88,7 @@ class Impression(utils_impression.Impression):
 
                 style = TableStyle([
                     ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                    ('FONT', (0, 0), (0, -1), "Helvetica", 9),
+                    ('FONT', (0, 0), (0, -1), utils_polices.FONT_NORMAL, 9),
                     ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
                     ('ALIGN', (0, 0), (0, -1), 'RIGHT'),
                 ])

--- a/noethysweb/individus/utils/utils_impression_anniversaires.py
+++ b/noethysweb/individus/utils/utils_impression_anniversaires.py
@@ -5,7 +5,7 @@
 
 import logging
 logger = logging.getLogger(__name__)
-from core.utils import utils_dates, utils_impression
+from core.utils import utils_dates, utils_impression, utils_polices
 from reportlab.platypus import Spacer, Table, TableStyle, PageBreak
 from reportlab.platypus.doctemplate import PageTemplate, BaseDocTemplate
 from reportlab.platypus.flowables import Image, DocAssign
@@ -58,7 +58,7 @@ class MyPageTemplate(PageTemplate):
         canvas.setFillColorRGB(0.7, 0.7, 1)
         canvas.rect(self.margeBord, self.pageHeight - self.margeBord, self.pageWidth - (self.margeBord * 2), -38, fill=1)
 
-        canvas.setFont("Helvetica-Bold", 24)
+        canvas.setFont(utils_polices.FONT_BOLD, 24)
         canvas.setFillColorRGB(0, 0, 0)
         canvas.drawString(self.margeBord + 10, self.pageHeight - self.margeBord - 26, nomMois)
 
@@ -156,12 +156,12 @@ class Impression(utils_impression.Impression):
                     ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
                     ('BACKGROUND', (0, 0), (-1, -1), couleurFondTableau),
 
-                    ('FONT', (0, 0), (-1, -1), "Helvetica", 7),
+                    ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
                     ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
                     ('ALIGN', (0, 1), (-1, -1), 'CENTRE'),
 
                     ('SPAN', (0, 0), (-1, 0)),
-                    ('FONT', (0, 0), (0, 0), "Helvetica-Bold", 10),
+                    ('FONT', (0, 0), (0, 0), utils_polices.FONT_BOLD, 10),
                     ('BACKGROUND', (0, 0), (-1, 0), couleurFondJour),
                 ])
 

--- a/noethysweb/individus/utils/utils_impression_contacts.py
+++ b/noethysweb/individus/utils/utils_impression_contacts.py
@@ -15,7 +15,7 @@ from reportlab.lib import colors
 from core.models import Activite, Groupe, Lien, Rattachement, ContactUrgence
 from core.data.data_liens import DICT_TYPES_LIENS
 from core.data import data_civilites
-from core.utils import utils_dates, utils_impression
+from core.utils import utils_dates, utils_impression, utils_polices
 
 
 class Impression(utils_impression.Impression):
@@ -65,9 +65,9 @@ class Impression(utils_impression.Impression):
             self.erreurs.append("Aucun individu n'a été trouvé avec les paramètres donnés")
 
         # Préparation des polices
-        style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
-        style_centre = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceAfter=0, leading=9)
-        style_detail = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=6, textColor="gray", spaceAfter=0, leading=8)
+        style_defaut = ParagraphStyle(name="defaut", fontName=utils_polices.FONT_NORMAL, fontSize=7, spaceAfter=0, leading=9)
+        style_centre = ParagraphStyle(name="centre", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=7, spaceAfter=0, leading=9)
+        style_detail = ParagraphStyle(name="centre", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=6, textColor="gray", spaceAfter=0, leading=8)
 
         # Création du titre du document
         self.Insert_header()
@@ -163,7 +163,7 @@ class Impression(utils_impression.Impression):
         # Finalisation du tableau
         style = TableStyle([
             ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-            ('FONT', (0, 0), (-1, -1), "Helvetica", 7),
+            ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
             ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
             ('ALIGN', (0, 0), (-1, -1), 'CENTRE'),
         ])

--- a/noethysweb/individus/utils/utils_impression_informations.py
+++ b/noethysweb/individus/utils/utils_impression_informations.py
@@ -13,7 +13,7 @@ from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.pagesizes import A4, portrait, landscape
 from reportlab.lib import colors
 from core.models import Activite, Rattachement, RegimeAlimentaire, Information
-from core.utils import utils_dates, utils_impression
+from core.utils import utils_dates, utils_impression, utils_polices
 
 
 class Impression(utils_impression.Impression):
@@ -52,9 +52,9 @@ class Impression(utils_impression.Impression):
             self.erreurs.append("Aucun individu n'a été trouvé avec les paramètres donnés")
 
         # Préparation des polices
-        style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
-        style_centre = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceAfter=0, leading=9)
-        style_detail = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=6, textColor="gray", spaceAfter=0, leading=8)
+        style_defaut = ParagraphStyle(name="defaut", fontName=utils_polices.FONT_NORMAL, fontSize=7, spaceAfter=0, leading=9)
+        style_centre = ParagraphStyle(name="centre", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=7, spaceAfter=0, leading=9)
+        style_detail = ParagraphStyle(name="centre", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=6, textColor="gray", spaceAfter=0, leading=8)
 
         # Création du titre du document
         self.Insert_header()
@@ -98,7 +98,7 @@ class Impression(utils_impression.Impression):
         # Finalisation du tableau
         style = TableStyle([
             ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-            ('FONT', (0, 0), (-1, -1), "Helvetica", 7),
+            ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
             ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
             ('ALIGN', (0, 0), (-1, -1), 'CENTRE'),
         ])

--- a/noethysweb/individus/utils/utils_impression_inscrits.py
+++ b/noethysweb/individus/utils/utils_impression_inscrits.py
@@ -102,7 +102,7 @@ class Impression(utils_impression.Impression):
 
         # Préparation des polices
         style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
-        style_activite = ParagraphStyle(name="centre", fontName="Helvetica-bold", alignment=1, fontSize=8, spaceBefore=0, spaceAfter=20, leading=0)
+        style_activite = ParagraphStyle(name="centre", fontName="Helvetica-Bold", alignment=1, fontSize=8, spaceBefore=0, spaceAfter=20, leading=0)
         style_infos = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceBefore=10, spaceAfter=0, leading=0)
 
         # Création du titre du document

--- a/noethysweb/individus/utils/utils_impression_inscrits.py
+++ b/noethysweb/individus/utils/utils_impression_inscrits.py
@@ -12,7 +12,7 @@ from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.pagesizes import A4, portrait, landscape
 from reportlab.lib import colors
 from core.models import Inscription, Ventilation, Prestation, Rattachement, Cotisation, ContactUrgence, Scolarite
-from core.utils import utils_texte, utils_impression, utils_questionnaires
+from core.utils import utils_texte, utils_impression, utils_questionnaires, utils_polices
 
 
 class Impression(utils_impression.Impression):
@@ -101,9 +101,9 @@ class Impression(utils_impression.Impression):
         questionnaires_familles = utils_questionnaires.ChampsEtReponses(categorie="famille", filtre_reponses=Q(famille__in=[i.famille for i in inscriptions]))
 
         # Préparation des polices
-        style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
-        style_activite = ParagraphStyle(name="centre", fontName="Helvetica-Bold", alignment=1, fontSize=8, spaceBefore=0, spaceAfter=20, leading=0)
-        style_infos = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceBefore=10, spaceAfter=0, leading=0)
+        style_defaut = ParagraphStyle(name="defaut", fontName=utils_polices.FONT_NORMAL, fontSize=7, spaceAfter=0, leading=9)
+        style_activite = ParagraphStyle(name="centre", fontName=utils_polices.FONT_BOLD, alignment=1, fontSize=8, spaceBefore=0, spaceAfter=20, leading=0)
+        style_infos = ParagraphStyle(name="centre", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=7, spaceBefore=10, spaceAfter=0, leading=0)
 
         # Création du titre du document
         self.Insert_header()
@@ -168,7 +168,7 @@ class Impression(utils_impression.Impression):
         # Finalisation du tableau
         style = TableStyle([
             ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-            ('FONT', (0, 0), (-1, -1), "Helvetica", 7),
+            ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
             ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
             ('ALIGN', (0, 0), (-1, -1), 'CENTRE'),
         ])

--- a/noethysweb/individus/utils/utils_impression_renseignements.py
+++ b/noethysweb/individus/utils/utils_impression_renseignements.py
@@ -16,7 +16,7 @@ from reportlab.lib import colors
 from core.models import Lien, Rattachement, ContactUrgence, Information, Assurance, Organisateur, Scolarite
 from core.data.data_liens import DICT_TYPES_LIENS
 from core.data import data_civilites
-from core.utils import utils_dates, utils_impression, utils_questionnaires
+from core.utils import utils_dates, utils_impression, utils_questionnaires, utils_polices
 from individus.utils import utils_vaccinations
 
 
@@ -138,10 +138,10 @@ class Impression(utils_impression.Impression):
                 self.export_xlsx["colonnes"].append({"code": "question_%s" % dict_question["IDquestion"], "titre": dict_question["label"]})
 
         # Préparation des polices
-        style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
-        style_centre = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceAfter=0, leading=9)
-        style_droite = ParagraphStyle(name="droite", fontName="Helvetica", alignment=2, fontSize=7, spaceAfter=0, leading=9)
-        style_identite = ParagraphStyle(name="identite", fontName="Helvetica-Bold", fontSize=16, spaceAfter=0, leading=28)
+        style_defaut = ParagraphStyle(name="defaut", fontName=utils_polices.FONT_NORMAL, fontSize=7, spaceAfter=0, leading=9)
+        style_centre = ParagraphStyle(name="centre", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=7, spaceAfter=0, leading=9)
+        style_droite = ParagraphStyle(name="droite", fontName=utils_polices.FONT_NORMAL, alignment=2, fontSize=7, spaceAfter=0, leading=9)
+        style_identite = ParagraphStyle(name="identite", fontName=utils_polices.FONT_BOLD, fontSize=16, spaceAfter=0, leading=28)
 
         def Img(fichier=""):
             return "<img src='%s/images/%s' width='6' height='6' valign='middle'/> " % (settings.STATIC_ROOT, fichier)
@@ -153,12 +153,12 @@ class Impression(utils_impression.Impression):
             style = [
                 ('SPAN', (0, 1), (-1, 1)),
                 ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                ('FONT', (0, 0), (-1, -1), "Helvetica", 7),
+                ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
                 ('LINEBEFORE', (0, 0), (0, -1), 0.25, colors.black),
                 ('LINEAFTER', (-1, 0), (-1, -1), 0.25, colors.black),
                 ('ALIGN', (0, 0), (-1, -1), 'CENTRE'),
-                ('FONT', (0, 0), (0, 0), "Helvetica-Bold", 7),
-                ('FONT', (1, 0), (1, 0), "Helvetica", 6),
+                ('FONT', (0, 0), (0, 0), utils_polices.FONT_BOLD, 7),
+                ('FONT', (1, 0), (1, 0), utils_polices.FONT_NORMAL, 6),
                 ('TEXTCOLOR', (0, 0), (-1, 0), (1, 1, 1)),
                 ('BACKGROUND', (0, 0), (-1, 0), (0.5, 0.5, 0.5)),
                 ('ALIGN', (0, 0), (-1, 0), 'LEFT'),
@@ -271,7 +271,7 @@ class Impression(utils_impression.Impression):
                 ('BOX', (0, 0), (-1, -1), 0.25, colors.black),
                 ('VALIGN', (0, 0), (-1, -1), 'TOP'),
                 ('ALIGN', (2, 0), (2, 0), 'RIGHT'),
-                ('FONT', (2, 0), (2, 0), "Helvetica", 6),
+                ('FONT', (2, 0), (2, 0), utils_polices.FONT_NORMAL, 6),
                 ('LEFTPADDING', (0, 0), (0, 0), 0),
                 ('TOPPADDING', (0, 0), (0, 0), 0),
                 ('BOTTOMPADDING', (0, 0), (0, 0), 0),
@@ -464,7 +464,7 @@ class Impression(utils_impression.Impression):
                 tableau = Table(contenu_tableau, [largeur_contenu/6] * 6)
                 tableau.setStyle(TableStyle([
                     ('VALIGN', (0, 0), (-1, -1), 'MIDDLE'),
-                    ('FONT', (0, 0), (-1, -1), "Helvetica", 7),
+                    ('FONT', (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
                 ]))
             else:
                 tableau = [Paragraph("Aucune vaccination obligatoire", style_defaut)]

--- a/noethysweb/locations/utils/utils_impression_location.py
+++ b/noethysweb/locations/utils/utils_impression_location.py
@@ -5,7 +5,7 @@
 
 import logging
 logger = logging.getLogger(__name__)
-from core.utils import utils_impression
+from core.utils import utils_impression, utils_polices
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.platypus import PageBreak
 from reportlab.platypus.flowables import DocAssign
@@ -18,7 +18,7 @@ class Impression(utils_impression.Impression):
     def Draw(self):
         styleSheet = getSampleStyleSheet()
         styleTexte = styleSheet['BodyText']
-        styleTexte.fontName = "Helvetica"
+        styleTexte.fontName = utils_polices.FONT_NORMAL
         styleTexte.fontSize = 9
         styleTexte.borderPadding = 9
         styleTexte.leading = 12

--- a/noethysweb/outils/utils/utils_impression_commande.py
+++ b/noethysweb/outils/utils/utils_impression_commande.py
@@ -11,7 +11,7 @@ from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib.pagesizes import A4, portrait, landscape
 from reportlab.lib import colors
 from core.models import Commande, CommandeModeleColonne
-from core.utils import utils_dates, utils_impression
+from core.utils import utils_dates, utils_impression, utils_polices
 
 
 class Impression(utils_impression.Impression):
@@ -29,14 +29,14 @@ class Impression(utils_impression.Impression):
         self.Insert_header()
 
         # Insère le nom et la période de la commande
-        style_titre_commande = ParagraphStyle(name="1", alignment=1, fontName="Helvetica-Bold", fontSize=9, leading=8, spaceAfter=14)
+        style_titre_commande = ParagraphStyle(name="1", alignment=1, fontName=utils_polices.FONT_BOLD, fontSize=9, leading=8, spaceAfter=14)
         self.story.append(Paragraph("<para>%s - Du %s au %s</para>" % (commande.nom, commande.date_debut.strftime("%d/%m/%Y"), commande.date_fin.strftime("%d/%m/%Y")), style_titre_commande))
 
         # Styles
-        style_entete = ParagraphStyle(name="1", alignment=1, fontName="Helvetica-Bold", fontSize=7, leading=8, spaceAfter=2)
-        style_numerique = ParagraphStyle(name="2", alignment=2, fontName="Helvetica", fontSize=7, leading=8, spaceAfter=2)
-        style_total = ParagraphStyle(name="3", alignment=2, fontName="Helvetica-Bold", fontSize=7, leading=8, spaceAfter=2)
-        style_texte = ParagraphStyle(name="4", alignment=0, fontName="Helvetica", fontSize=7, leading=8, spaceAfter=2)
+        style_entete = ParagraphStyle(name="1", alignment=1, fontName=utils_polices.FONT_BOLD, fontSize=7, leading=8, spaceAfter=2)
+        style_numerique = ParagraphStyle(name="2", alignment=2, fontName=utils_polices.FONT_NORMAL, fontSize=7, leading=8, spaceAfter=2)
+        style_total = ParagraphStyle(name="3", alignment=2, fontName=utils_polices.FONT_BOLD, fontSize=7, leading=8, spaceAfter=2)
+        style_texte = ParagraphStyle(name="4", alignment=0, fontName=utils_polices.FONT_NORMAL, fontSize=7, leading=8, spaceAfter=2)
 
         # Calcule des largeurs de colonne
         largeur_colonne_date = 110
@@ -97,11 +97,11 @@ class Impression(utils_impression.Impression):
 
         listeStyles = [
                 ('VALIGN', (0,0), (-1,-1), 'MIDDLE'),
-                ('FONT',(0,0),(-1,-1), "Helvetica", 7),
+                ("FONT",(0,0),(-1,-1), utils_polices.FONT_NORMAL, 7),
                 ('GRID', (0, 0), (-1, -1), 0.25, colors.black),
                 ('ALIGN', (0,1), (-2,-1), 'CENTER'),
-                ('FONT', (0, 0), (0, -1), "Helvetica-Bold", 7),
-                ('FONT', (0, 0), (-1, 0), "Helvetica-Bold", 7),
+                ('FONT', (0, 0), (0, -1), utils_polices.FONT_BOLD, 7),
+                ('FONT', (0, 0), (-1, 0), utils_polices.FONT_BOLD, 7),
                 ]
 
         # Création du tableau
@@ -111,7 +111,7 @@ class Impression(utils_impression.Impression):
 
         # Observations
         if commande.observations:
-            style_observations = ParagraphStyle(name="2", alignment=1, fontName="Helvetica", fontSize=7, leading=8, spaceBefore=10)
+            style_observations = ParagraphStyle(name="2", alignment=1, fontName=utils_polices.FONT_NORMAL, fontSize=7, leading=8, spaceBefore=10)
             self.story.append(Paragraph(commande.observations, style=style_observations))
 
         # Mémorisation des champs de fusion

--- a/noethysweb/reglements/utils/utils_impression_depot_reglements.py
+++ b/noethysweb/reglements/utils/utils_impression_depot_reglements.py
@@ -11,7 +11,7 @@ from reportlab.platypus import Spacer, Paragraph, Table, TableStyle
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib import colors
 from core.models import Depot, Reglement
-from core.utils import utils_impression, utils_texte
+from core.utils import utils_dates, utils_impression, utils_texte, utils_polices
 
 
 class Impression(utils_impression.Impression):
@@ -32,9 +32,9 @@ class Impression(utils_impression.Impression):
         reglements = Reglement.objects.select_related("famille", "mode", "emetteur", "payeur").filter(depot=depot).order_by(tri)
 
         # Préparation des polices
-        style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
-        style_centre = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceAfter=0, leading=9)
-        style_titre = ParagraphStyle(name="titre", fontName="Helvetica-Bold", alignment=1, fontSize=11, spaceAfter=0, leading=11)
+        style_defaut = ParagraphStyle(name="defaut", fontName=utils_polices.FONT_NORMAL, fontSize=7, spaceAfter=0, leading=9)
+        style_centre = ParagraphStyle(name="centre", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=7, spaceAfter=0, leading=9)
+        style_titre = ParagraphStyle(name="titre", fontName=utils_polices.FONT_BOLD, alignment=1, fontSize=11, spaceAfter=0, leading=11)
 
         # Création du titre du document
         self.Insert_header()
@@ -114,7 +114,7 @@ class Impression(utils_impression.Impression):
         # Finalisation du tableau
         style = TableStyle([
             ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-            ("FONT", (0, 0), (-1, -1), "Helvetica", 7),
+            ("FONT", (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
             ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
             ("ALIGN", (0, 0), (-1, -1), "CENTRE"),
         ])

--- a/noethysweb/reglements/utils/utils_impression_depot_reglements.py
+++ b/noethysweb/reglements/utils/utils_impression_depot_reglements.py
@@ -34,7 +34,7 @@ class Impression(utils_impression.Impression):
         # Préparation des polices
         style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
         style_centre = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceAfter=0, leading=9)
-        style_titre = ParagraphStyle(name="titre", fontName="Helvetica-bold", alignment=1, fontSize=11, spaceAfter=0, leading=11)
+        style_titre = ParagraphStyle(name="titre", fontName="Helvetica-Bold", alignment=1, fontSize=11, spaceAfter=0, leading=11)
 
         # Création du titre du document
         self.Insert_header()

--- a/noethysweb/reglements/utils/utils_impression_ventilations_reglements.py
+++ b/noethysweb/reglements/utils/utils_impression_ventilations_reglements.py
@@ -11,7 +11,7 @@ from reportlab.platypus import Spacer, Paragraph, Table, TableStyle
 from reportlab.lib.styles import ParagraphStyle
 from reportlab.lib import colors
 from core.models import Reglement, Ventilation
-from core.utils import utils_impression, utils_texte
+from core.utils import utils_impression, utils_texte, utils_polices
 
 
 class Impression(utils_impression.Impression):
@@ -40,9 +40,9 @@ class Impression(utils_impression.Impression):
             dict_ventilations_reglement[ventilation.reglement].append(ventilation)
 
         # Préparation des polices
-        style_defaut = ParagraphStyle(name="defaut", fontName="Helvetica", fontSize=7, spaceAfter=0, leading=9)
-        style_centre = ParagraphStyle(name="centre", fontName="Helvetica", alignment=1, fontSize=7, spaceAfter=0, leading=9)
-        style_droite = ParagraphStyle(name="right", fontName="Helvetica", alignment=2, fontSize=7, spaceAfter=0, leading=9)
+        style_defaut = ParagraphStyle(name="defaut", fontName=utils_polices.FONT_NORMAL, fontSize=7, spaceAfter=0, leading=9)
+        style_centre = ParagraphStyle(name="centre", fontName=utils_polices.FONT_NORMAL, alignment=1, fontSize=7, spaceAfter=0, leading=9)
+        style_droite = ParagraphStyle(name="right", fontName=utils_polices.FONT_NORMAL, alignment=2, fontSize=7, spaceAfter=0, leading=9)
 
         # Création du titre du document
         self.Insert_header()
@@ -57,7 +57,7 @@ class Impression(utils_impression.Impression):
             largeurs=[50, 90, 50, 230, 50, 50],
             styles=[
                 ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-                ("FONT", (0, 0), (-1, -1), "Helvetica", 7),
+                ("FONT", (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
                 ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
                 ("ALIGN", (0, 0), (-1, -1), "CENTRE")],
             lignes=[],
@@ -72,7 +72,7 @@ class Impression(utils_impression.Impression):
                 largeurs=[50, 90, 50, 230, 50, 50],
                 styles=[
                     ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-                    ("FONT", (0, 0), (-1, -1), "Helvetica", 7),
+                    ("FONT", (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
                     ("BOX", (0, 0), (-1, -1), 0.25, colors.black),
                     ("ALIGN", (0, 0), (-1, -1), "CENTRE"),
                     ("BACKGROUND", (0, 0), (-1, 0), (0.8, 0.8, 0.8)),],
@@ -92,7 +92,7 @@ class Impression(utils_impression.Impression):
                 largeurs=[50, 140, 120, 160, 50],
                 styles=[
                     ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-                    ("FONT", (0, 0), (-1, -1), "Helvetica", 5),
+                    ("FONT", (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 5),
                     ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
                     ("ALIGN", (0, 0), (-1, -1), "CENTRE")],
                 lignes=[],
@@ -104,7 +104,7 @@ class Impression(utils_impression.Impression):
                     largeurs=[50, 140, 120, 160, 50],
                     styles=[
                         ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
-                        ("FONT", (0, 0), (-1, -1), "Helvetica", 7),
+                        ("FONT", (0, 0), (-1, -1), utils_polices.FONT_NORMAL, 7),
                         ("GRID", (0, 0), (-1, -1), 0.25, colors.black),
                         ("ALIGN", (0, 0), (-1, -1), "CENTRE")],
                     lignes=[(


### PR DESCRIPTION
Bonjour,

Comme indiqué dans l'issue #60 certains pdf ne se génèrent pas a cause d'un problème d'import de la police bold qui est écrite avec une erreur de case ("Helvetica-bold" au lieu de "Helvetica-Bold") avec certaines versions spécifiques de reportlab.

Cette PR vient donc proposer de corriger les imports qui ont ce problème, puis dans un seconde temps elle propose de centraliser le nom des polices dans des constantes pour en simplifier un future changement et réduire le risque d'erreur dans leurs noms.