### PR TITLE
Problème sur la permission desk_creer qui créé une migration a l'installation pour rien.

### DIFF
--- a/noethysweb/core/test_desk_creer_bug.py
+++ b/noethysweb/core/test_desk_creer_bug.py
@@ -1,0 +1,39 @@
+# -*- coding: utf-8 -*-
+# Test pour mettre en évidence le bug de permission desk_creer
+
+from django.test import TestCase, override_settings
+from core.utils.utils_permissions import GetPermissionsPossibles
+
+
+class TestDeskCreerBug(TestCase):
+    """Test qui met en évidence le problème de migration de permission desk_creer"""
+
+    def test_desk_creer_permission_missing_without_secret_export_desk(self):
+        """
+        Ce test met en évidence le bug :
+        Quand SECRET_EXPORT_DESK=None, la permission desk_creer n'est pas générée,
+        ce qui cause sa suppression lors des migrations.
+        """
+        with override_settings(SECRET_EXPORT_DESK=None):
+            permissions = GetPermissionsPossibles()
+            desk_creer_permissions = [perm for perm in permissions 
+                                   if perm[0] == 'desk_creer']
+            
+            # Ce test va échouer, démontrant le problème
+            self.assertEqual(len(desk_creer_permissions), 1,
+                           "PROBLÈME DÉTECTÉ: La permission 'desk_creer' n'est pas "
+                           "générée quand SECRET_EXPORT_DESK=None. "
+                           "Cela explique pourquoi elle est supprimée lors des migrations.")
+
+    def test_desk_creer_permission_present_with_secret_export_desk(self):
+        """
+        Test normal : avec SECRET_EXPORT_DESK défini, la permission devrait être présente.
+        """
+        with override_settings(SECRET_EXPORT_DESK="test_value"):
+            permissions = GetPermissionsPossibles()
+            desk_creer_permissions = [perm for perm in permissions 
+                                   if perm[0] == 'desk_creer']
+            
+            self.assertEqual(len(desk_creer_permissions), 1,
+                           "La permission 'desk_creer' devrait être présente "
+                           "quand SECRET_EXPORT_DESK est défini.")

--- a/noethysweb/core/utils/utils_permissions.py
+++ b/noethysweb/core/utils/utils_permissions.py
@@ -14,18 +14,12 @@ def GetPermissionsPossibles(organisateur=None):
 
     # Commandes de menu
     menu_principal = GetMenuPrincipal(organisateur=organisateur, force_permissions=True)
-    #menu_principal = GetMenuPrincipal(organisateur=organisateur)
+
     for menu in menu_principal.GetChildren():
         for sous_menu in menu.GetChildren():
             for commande in sous_menu.GetChildren():
                 liste_permissions.append((commande.code, "%s | %s" % (commande.parent.parent.titre, commande.titre)))
     
-    # Ajout manuel de la permission desk_creer pour garantir sa présence
-    # même quand SECRET_EXPORT_DESK=None (menu masqué mais permission conservée)
-    #desk_creer_present = any(perm[0] == 'desk_creer' for perm in liste_permissions)
-    #if not desk_creer_present:
-    #    liste_permissions.append(('desk_creer', 'Outils | Récupérer les données'))
-
     # Fiche famille
     for commande in LISTE_ONGLETS_FAMILLES:
         liste_permissions.append(("famille_%s" % commande["code"], "Fiche famille | %s" % commande["label"]))

--- a/noethysweb/core/utils/utils_permissions.py
+++ b/noethysweb/core/utils/utils_permissions.py
@@ -13,11 +13,18 @@ def GetPermissionsPossibles(organisateur=None):
     liste_permissions = []
 
     # Commandes de menu
-    menu_principal = GetMenuPrincipal(organisateur=organisateur)
+    menu_principal = GetMenuPrincipal(organisateur=organisateur, force_permissions=True)
+    #menu_principal = GetMenuPrincipal(organisateur=organisateur)
     for menu in menu_principal.GetChildren():
         for sous_menu in menu.GetChildren():
             for commande in sous_menu.GetChildren():
                 liste_permissions.append((commande.code, "%s | %s" % (commande.parent.parent.titre, commande.titre)))
+    
+    # Ajout manuel de la permission desk_creer pour garantir sa présence
+    # même quand SECRET_EXPORT_DESK=None (menu masqué mais permission conservée)
+    #desk_creer_present = any(perm[0] == 'desk_creer' for perm in liste_permissions)
+    #if not desk_creer_present:
+    #    liste_permissions.append(('desk_creer', 'Outils | Récupérer les données'))
 
     # Fiche famille
     for commande in LISTE_ONGLETS_FAMILLES:

--- a/noethysweb/core/views/menu.py
+++ b/noethysweb/core/views/menu.py
@@ -8,7 +8,6 @@ from django.urls import reverse_lazy
 from django.conf import settings
 
 
-#def GetMenuPrincipal(organisateur=None, user=None):
 def GetMenuPrincipal(organisateur=None, user=None, force_permissions=False):
     menu = Menu(titre="Menu principal", user=user, force_permissions=force_permissions)
 

--- a/noethysweb/core/views/menu.py
+++ b/noethysweb/core/views/menu.py
@@ -8,8 +8,9 @@ from django.urls import reverse_lazy
 from django.conf import settings
 
 
-def GetMenuPrincipal(organisateur=None, user=None):
-    menu = Menu(titre="Menu principal", user=user)
+#def GetMenuPrincipal(organisateur=None, user=None):
+def GetMenuPrincipal(organisateur=None, user=None, force_permissions=False):
+    menu = Menu(titre="Menu principal", user=user, force_permissions=force_permissions)
 
     # ------------------------------------ Accueil ------------------------------------
     menu.Add(code="accueil", titre="Accueil", icone="home", toujours_afficher=True)
@@ -563,7 +564,7 @@ def GetMenuPrincipal(organisateur=None, user=None):
 
 
 class Menu():
-    def __init__(self, parent=None, code="", titre="", icone=None, url=None, user=None, toujours_afficher=False, compatible_demo=True, masquer=False, args=None):
+    def __init__(self, parent=None, code="", titre="", icone=None, url=None, user=None, toujours_afficher=False, compatible_demo=True, masquer=False, force_permissions=False, args=None):
         self.parent = parent
         self.code = code
         self.titre = titre
@@ -575,6 +576,7 @@ class Menu():
         self.toujours_afficher = toujours_afficher
         self.compatible_demo = compatible_demo
         self.masquer = masquer
+        self.force_permissions = force_permissions
 
     def __repr__(self):
         return "<Menu '%s'>" % self.titre
@@ -583,10 +585,18 @@ class Menu():
         return self.parent
 
     def Add(self, code="", titre="", icone="", url=None, toujours_afficher=False, compatible_demo=True, args=None, superutilisateur_only=False, masquer=False):
-        menu = Menu(self, code=code, titre=titre, icone=icone, url=url, args=args, user=self.user, compatible_demo=compatible_demo, toujours_afficher=toujours_afficher, masquer=masquer)
-        afficher = not code or not self.user or toujours_afficher or code.endswith("_toc") or self.user.has_perm("core.%s" % code)
-        if masquer or (self.user and superutilisateur_only and not self.user.is_superuser):
-            afficher = False
+        # Créer l'objet menu
+        menu = Menu(self, code=code, titre=titre, icone=icone, url=url, args=args, user=self.user, compatible_demo=compatible_demo, toujours_afficher=toujours_afficher, masquer=masquer, force_permissions=self.force_permissions)
+        
+        afficher = True # Par défaut, on affiche tout
+        
+        # Si on n'est pas en mode force_permissions pour générer les permissions, on vérifie si l'on doit ou non afficher le menu
+        if not self.force_permissions:
+            afficher = not code or not self.user or toujours_afficher or code.endswith("_toc") or self.user.has_perm("core.%s" % code)
+            
+            if masquer or (self.user and superutilisateur_only and not self.user.is_superuser):
+                afficher = False
+    
         if afficher:
             self.children.append(menu)
         return menu


### PR DESCRIPTION
Bonjour,

Lors de la procédure d'installation, au moment de faire le `python3 manage.py makemigrations` django génére deux requêtes de migration, une sur le modèle `unite` (#63) et une autre relative aux permissions.

Cette PR a pour but de supprimer une fois pour toute cette requête de migration sur la permission `desk_creer` car cette requête vient du fait qu'il est nécessaire de posséder une variable de conf qui par défaut n'est pas présente.

Voici le détail du problème : 

Il y'a une série de 3 commits qui ont mit en place le menu "desk_creer".

Le 17/01/2025 [88f458ee19039fc95a5eb8b4afc9489681c8facc](https://github.com/Noethys/Noethysweb/commit/88f458ee19039fc95a5eb8b4afc9489681c8facc) : Ce commit vient ajouter le menu `desk_creer` dans `noethysweb/core/views/menu.py`
```
    menu_sauvegarde.Add(code="desk_creer", titre="Récupérer les données", icone="file-text-o", compatible_demo=False, superutilisateur_only=True, masquer=not settings.SECRET_EXPORT_DESK)
```

On voit que l'affichage de ce menu est conditionné à la présence de la variable de settings `SECRET_EXPORT_DESK`.

Le 19/01/2025 [eac5a64891339f377fece0ce67221f676017bf98](https://github.com/Noethys/Noethysweb/commit/eac5a64891339f377fece0ce67221f676017bf98) : Ce commit vient ajouter la migration qui contient la permission `desk_creer`, pourtant dans ces conditions la permission ne devrait pas être disponible car la variable `SECRET_EXPORT_DESK` n'existe pas.

Le 19/01/2025 [67b975d5d4a1c3b6dadc1387fd1073c4ab81c15b](https://github.com/Noethys/Noethysweb/commit/67b975d5d4a1c3b6dadc1387fd1073c4ab81c15b) : Ce commit vient ajouter dans `settings.py` la variable `SECRET_EXPORT_DESK` en l'affectant à `none`, donc avec cette valeur la permission `desk_creer` ne peux toujours pas être créé.

Après cette analyse, j'en conclus que pour avoir été généré dans la requête de migration la permission `desk_creer`, il fallait que la variable `SECRET_EXPORT_DESK` existe et soit affectée a une valeur différente de `none`.
Donc au moment de la génération de la requête de migration 182, et lors des `makemigrations` suivants, il devait y avoir, et il doit toujours y avoir, une variable `SECRET_EXPORT_DESK` dans votre fichier `settings_production.py` affecté a une valeur autre que `none`.
Cette variable n'étant pas listé dans le `settings_production_modele.py` nous ne l'avons pas dans notre cas dans notre fichier `settings_production.py` et c'est ce qui explique que nous avons cette requête de migration qui enlève la permission `desk_creer`.

J'imagine qu'il est normal de cacher le menu mais que la suppression de la permission qui va avec est un accident.

J'ai donc créé cette PR pour corriger ce problème en forçant l'apparition du menu dans le cas de la génération des permissions.

J'ai aussi ajouté une série de tests permettant de mettre en évidence le problème et que la PR le corrige.
Pour lancer la série de test :
```
python3 manage.py test core.test_desk_creer_bug
```